### PR TITLE
現在時刻の取得経路を Current.time に一本化する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,8 +8,18 @@ plugins:
   - rubocop-rspec_rails
   - rubocop-factory_bot
 
+# 自作 cop。plugin gem ではないので require で読む。
+# 置き場所は lib/ ではなく .rubocop/ にしている。lib/ は config.autoload_lib の
+# 対象で、Zeitwerk が RuboCop を Rubocop と読もうとして解決に失敗するため
+require:
+  - ./.rubocop/cop/okuribon/current_time.rb
+
 AllCops:
   NewCops: enable
+  # 隠しディレクトリは既定で走査対象外なので、自作 cop 自身を明示的に含める
+  Include:
+    - "**/*.rb"
+    - ".rubocop/cop/**/*.rb"
   Exclude:
     - "bin/**/*"
     - "db/schema.rb"
@@ -62,3 +72,15 @@ RSpec/DescribeClass:
 # クラスに説明コメントを必須としない
 Style/Documentation:
   Enabled: false
+
+# --- 現在時刻の取得経路 ---
+
+# 現在時刻は Current.time に一本化する（フェーズを日時から導出するため）。
+# 対象はアプリケーションコードだけ。config・spec・マイグレーションは実時刻を直接扱う
+Okuribon/CurrentTime:
+  Enabled: true
+  Include:
+    - "app/**/*.rb"
+    - "lib/**/*.rb"
+  Exclude:
+    - "app/models/current.rb"

--- a/.rubocop/cop/okuribon/current_time.rb
+++ b/.rubocop/cop/okuribon/current_time.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Okuribon
+      # 現在時刻の取得を Current.time に一本化する。
+      #
+      # フェーズを日時から導出するため、開発中に時刻を前後させられる経路を通す必要がある。
+      # rubocop-rails の Rails/TimeZone と Rails/Date はタイムゾーン非対応の書き方だけを潰し、
+      # Time.current や Time.zone.now はむしろ推奨するため、この cop で塞ぐ。
+      #
+      # @example
+      #   # bad
+      #   Time.current
+      #   Time.zone.now
+      #   Date.today
+      #
+      #   # good
+      #   Current.time
+      class CurrentTime < Base
+        MSG = '現在時刻は `Current.time` から取得する。'
+
+        RESTRICT_ON_SEND = [:now, :current, :today].freeze
+
+        # Time / Date / DateTime を直接読む形と、Time.zone を経由する形の両方を拾う
+        def_node_matcher :direct_clock_read?, <<~PATTERN
+          (send
+            {
+              (const {nil? cbase} {:Time :Date :DateTime})
+              (send (const {nil? cbase} :Time) :zone)
+            }
+            _)
+        PATTERN
+
+        def on_send(node)
+          add_offense(node) if direct_clock_read?(node)
+        end
+      end
+    end
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# アプリ全体で唯一の現在時刻の取得元。
+# フェーズは日時から導出されるため、開発中に時刻を前後させられないと画面の確認ができない。
+# 直接 Time.zone.now を呼ばず、必ずここを通す（禁止は Okuribon/CurrentTime cop で機械的に検出する）。
+class Current < ActiveSupport::CurrentAttributes
+  attribute :time
+
+  # 書き込まれていなければ実時刻を返す。
+  # 代入された値は JST へ寄せる（開発環境で UTC の値を入れても表示がずれないようにする）。
+  def time
+    super&.in_time_zone || Time.zone.now
+  end
+end

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Current do
+  describe '.time' do
+    it '既定では現在時刻を返す' do
+      expect(described_class.time).to be_within(1.second).of(Time.zone.now)
+    end
+
+    it 'JST で返る' do
+      expect(described_class.time.time_zone.name).to eq('Tokyo')
+    end
+
+    it '代入した時刻を返す' do
+      fixed = Time.zone.local(2026, 7, 30, 12, 0, 0)
+      described_class.time = fixed
+
+      expect(described_class.time).to eq(fixed)
+    end
+
+    it 'UTC で代入しても JST で返る' do
+      described_class.time = Time.utc(2026, 7, 30, 3, 0, 0)
+
+      expect(described_class.time.time_zone.name).to eq('Tokyo')
+      expect(described_class.time).to eq(Time.zone.local(2026, 7, 30, 12, 0, 0))
+    end
+
+    it 'travel_to で固定した時刻を返す' do
+      fixed = Time.zone.local(2026, 7, 30, 12, 0, 0)
+
+      travel_to(fixed) do
+        expect(described_class.time).to eq(fixed)
+      end
+    end
+  end
+
+  # executor は Rails が1リクエストと1ジョブをそれぞれ包む単位。
+  # フェーズ判定が前のリクエストの時刻を引きずると、権限判定ごと壊れる。
+  describe 'リクエストの境界' do
+    it '代入した時刻が次のリクエストへ漏れない' do
+      fixed = Time.zone.local(2020, 1, 1)
+
+      Rails.application.executor.wrap { described_class.time = fixed }
+
+      Rails.application.executor.wrap do
+        expect(described_class.time).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+
+    it 'travel_to での固定はリクエストをまたいでも効く' do
+      fixed = Time.zone.local(2026, 7, 30, 12, 0, 0)
+
+      travel_to(fixed) do
+        Rails.application.executor.wrap do
+          expect(described_class.time).to eq(fixed)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/okuribon/current_time_spec.rb
+++ b/spec/rubocop/cop/okuribon/current_time_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../.rubocop/cop/okuribon/current_time'
+
+RSpec.describe RuboCop::Cop::Okuribon::CurrentTime, :config do
+  it 'Time.current を検出する' do
+    expect_offense(<<~RUBY)
+      Time.current
+      ^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Time.now を検出する' do
+    expect_offense(<<~RUBY)
+      Time.now
+      ^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Time.zone.now を検出する' do
+    expect_offense(<<~RUBY)
+      Time.zone.now
+      ^^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Time.zone.today を検出する' do
+    expect_offense(<<~RUBY)
+      Time.zone.today
+      ^^^^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Date.today を検出する' do
+    expect_offense(<<~RUBY)
+      Date.today
+      ^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Date.current を検出する' do
+    expect_offense(<<~RUBY)
+      Date.current
+      ^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'DateTime.now を検出する' do
+    expect_offense(<<~RUBY)
+      DateTime.now
+      ^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'トップレベル定数を明示しても検出する' do
+    expect_offense(<<~RUBY)
+      ::Time.current
+      ^^^^^^^^^^^^^^ 現在時刻は `Current.time` から取得する。
+    RUBY
+  end
+
+  it 'Current.time は許す' do
+    expect_no_offenses('Current.time')
+  end
+
+  it '時刻の生成は許す' do
+    expect_no_offenses('Time.zone.local(2026, 7, 30)')
+  end
+
+  it 'Time や Date 以外のレシーバは見ない' do
+    expect_no_offenses('exchange.now')
+  end
+end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# 時刻を前後させる spec を書けるようにする。フェーズ境界の検証で使う。
+#
+# 固定の手段は2つあり、リクエストをまたぐかどうかで使い分ける。
+#
+# - `Current.time = t` … モデルやサービスの spec 向け。リクエストの終わりに
+#   Rails の executor が CurrentAttributes を消すため、リクエストをまたぐと効かない
+# - `travel_to(t)` … リクエスト spec 向け。`Time.zone.now` 自体を差し替えるので、
+#   `Current.time` の既定値を通してリクエストをまたいでも効き続ける
+#
+# example 間のリセットは rspec-rails が
+# `ActiveSupport::CurrentAttributes::TestHelper` を include して行うため、ここでは足さない。
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
closes #4

フェーズを日時から導出するため、現在時刻の取得を1か所に集約し、開発中に前後させられるようにした。

## 変更点

### `Current.time` を唯一の取得元にする

`app/models/current.rb` に `ActiveSupport::CurrentAttributes` を置いた。書き込みがなければ `Time.zone.now` を返す。

`CurrentAttributes` を選んだ理由は、Rails の executor がリクエストとジョブの境界で `clear_all` するため（`activesupport/lib/active_support/railtie.rb` の `active_support.reset_execution_context`）。前のリクエストで固定した時刻が次へ漏れず、フェーズ判定が狂わない。

- **1リクエスト内でのメモ化は入れていない。** 読むたび実時刻へ進む。境界をまたぐ判定に一貫性が必要だと分かった時点で足す（#8 で判断する）
- 代入値は `in_time_zone` で JST へ寄せる。開発環境で UTC の値を入れても表示がずれないようにするため

### spec での時刻固定

`spec/support/time_helpers.rb` で `ActiveSupport::Testing::TimeHelpers` を有効化した。手段が2つあり使い分けが要るので、ファイル冒頭に書き残した。

| 手段 | 用途 |
|---|---|
| `Current.time = t` | モデル・サービスの spec。executor が境界で消すためリクエストをまたげない |
| `travel_to(t)` | リクエスト spec。`Time.zone.now` 自体を差し替えるのでまたいでも効く |

example 間のリセットは rspec-rails が `CurrentAttributes::TestHelper` を include してすでに行うため（`rspec-rails/lib/rspec/rails/example/rails_example_group.rb`）、自前では足していない。

### 直接呼び出しを検出する cop

**rubocop-rails では塞げなかった。** `Rails/TimeZone` と `Rails/Date` はタイムゾーン非対応の書き方だけを潰す cop で、`Time.current` と `Time.zone.now` はむしろ推奨先として案内してくる。禁じたいのはその2つなので方向が逆。`EnforcedStyle: strict` でも通る。RuboCop 本体にも汎用の禁止メソッド cop はない。実際に食わせて確認した。

そこで `.rubocop/cop/okuribon/current_time.rb` に自作 cop を置き、`Time.current` / `Time.now` / `Time.zone.now` / `Time.zone.today` / `Date.today` / `Date.current` / `DateTime.now` を検出する。

- 置き場所を `lib/` にしないのは、`lib/` が `config.autoload_lib` の対象で Zeitwerk が `RuboCop` を `Rubocop` と読もうとして失敗するため。`application.rb` の `ignore` を増やす手もあるが、lint 用のファイルのためにアプリの起動設定を触りたくないのでドット始まりのディレクトリへ置いた
- 隠しディレクトリは既定で走査対象外になるので、cop 自身が lint されるよう `AllCops/Include` に明示的に足している
- 対象は `app` と `lib` だけ。`config` と `spec`、マイグレーションは実時刻を直接扱う。`app/models/current.rb` は唯一の取得元なので除外

## 完了条件

すべて満たしている。

- [x] `Current.time` で現在時刻を取得できる
- [x] アプリケーションコードに直接呼び出しが無い（`Okuribon/CurrentTime` cop で検出できる）
- [x] spec から任意の時刻に固定でき、リクエストをまたいで漏れない
- [x] タイムゾーンが JST で返る

## 検証

- `bin/rspec` — 56 examples, 0 failures。各コミット単体でも通る（1つめの時点で 45 examples）
- `bin/rubocop` — 31 files, no offenses
- `bin/ci` — **`bin/bundler-audit` の段で落ちる。この PR とは無関係の既存の失敗。** `activestorage` の CVE-2026-66066 で、Rails 8.1.3 → 8.1.3.1 が必要。main でも同じく落ちることを確認済み。dependabot にも該当 PR はまだない。別途対応したい。rubocop・importmap audit・brakeman の各段は通る

## 不変条件

`invariants` を実行した。ギフトコードの可視性、サーバー側のフェーズ検証、状態カラム・乱数シード・マッチングの一回性は、いずれも該当するコードがまだ存在せず該当なし。現在時刻の取得経路は本 PR の主題で、grep が当たるのは `app/models/current.rb` の1行のみ。

以下は確認できていない。

- **マイグレーションの `now()`** — `db/migrate` が存在しないため対象なし。cop の対象も `app` と `lib` に絞っているので、将来のマイグレーションは網の外。#5 でテーブルを作るときに DB 側のデフォルト値を見る必要がある
- **ビューの残り時間表示** — ビューがまだない

🤖 Generated with [Claude Code](https://claude.com/claude-code)