### PR TITLE
Exchange の期間カラムの整合性を検証する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'thruster', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.2'
 
+# Rails 標準のメッセージと日付書式の日本語訳
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: [:mri, :windows], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,9 @@ GEM
     rails-html-sanitizer (1.7.1)
       loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3.1)
       actionpack (= 8.1.3.1)
       activesupport (= 8.1.3.1)
@@ -413,6 +416,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.3)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-factory_bot

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -10,4 +10,32 @@ class Exchange < ApplicationRecord
   validates :name, :invite_token, :random_seed,
             :registration_starts_at, :registration_ends_at, :wish_starts_at, :wish_ends_at,
             presence: true
+
+  validate :registration_period_order
+  validate :wish_period_order
+  validate :periods_do_not_overlap
+
+  private
+
+  def registration_period_order
+    return if registration_starts_at.blank? || registration_ends_at.blank?
+    return if registration_starts_at < registration_ends_at
+
+    errors.add(:registration_ends_at, :before_start)
+  end
+
+  def wish_period_order
+    return if wish_starts_at.blank? || wish_ends_at.blank?
+    return if wish_starts_at < wish_ends_at
+
+    errors.add(:wish_ends_at, :before_start)
+  end
+
+  # 各期間は開始時刻を含み終了時刻を含まないため、境界が同時刻でも重ならない
+  def periods_do_not_overlap
+    return if registration_ends_at.blank? || wish_starts_at.blank?
+    return if registration_ends_at <= wish_starts_at
+
+    errors.add(:wish_starts_at, :overlaps_registration)
+  end
 end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -5,4 +5,9 @@ class Exchange < ApplicationRecord
 
   has_many :participations, dependent: :destroy
   has_many :books, through: :participations
+
+  # NOT NULL のカラムは presence でも弾く。DB の例外ではなくフォームのエラーとして返すため
+  validates :name, :invite_token, :random_seed,
+            :registration_starts_at, :registration_ends_at, :wish_starts_at, :wish_ends_at,
+            presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,9 @@ module Okuribon
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :utc
 
+    # 画面もエラーメッセージも日本語だけを出す。ロケールの切り替えは持たない
+    config.i18n.default_locale = :ja
+
     # Don't generate system test files.
     config.generators.system_tests = nil
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  activerecord:
+    attributes:
+      exchange:
+        registration_starts_at: 登録期間の開始日時
+        registration_ends_at: 登録期間の終了日時
+        wish_starts_at: 希望提出期間の開始日時
+        wish_ends_at: 希望提出期間の終了日時
+    errors:
+      models:
+        exchange:
+          attributes:
+            registration_ends_at:
+              before_start: は開始日時より後にしてください
+            wish_ends_at:
+              before_start: は開始日時より後にしてください
+            wish_starts_at:
+              overlaps_registration: は登録期間の終了日時以降にしてください

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,9 @@ ja:
   activerecord:
     attributes:
       exchange:
+        name: 交換会名
+        invite_token: 招待トークン
+        random_seed: 乱数シード
         registration_starts_at: 登録期間の開始日時
         registration_ends_at: 登録期間の終了日時
         wish_starts_at: 希望提出期間の開始日時

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Exchange do
-  it '必須のカラムに nil を保存できない' do
+  # DB の例外にする前にバリデーションで捕まえる。フォームに戻せるのはこちらだけ
+  it '必須のカラムに nil を入れるとバリデーションで落ちる' do
     columns = [
       :name, :registration_starts_at, :registration_ends_at,
       :wish_starts_at, :wish_ends_at, :invite_token, :random_seed,
@@ -11,6 +12,19 @@ RSpec.describe Exchange do
 
     columns.each do |column|
       expect { create(:exchange, column => nil) }
+        .to raise_error(ActiveRecord::RecordInvalid), "#{column} に presence バリデーションが無い"
+    end
+  end
+
+  # バリデーションを外れた経路でも空で入らないよう、DB 側の制約も残す
+  it '必須のカラムはバリデーションを迂回しても保存できない' do
+    columns = [
+      :name, :registration_starts_at, :registration_ends_at,
+      :wish_starts_at, :wish_ends_at, :invite_token, :random_seed,
+    ]
+
+    columns.each do |column|
+      expect { build(:exchange, column => nil).save(validate: false) }
         .to raise_error(ActiveRecord::NotNullViolation), "#{column} が NOT NULL になっていない"
     end
   end

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -76,4 +76,115 @@ RSpec.describe Exchange do
     expect(described_class.column_names)
       .not_to include('phase', 'state', 'status', 'aasm_state')
   end
+
+  describe '期間の整合性' do
+    it '登録期間のあとに希望提出期間が並んでいれば有効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-10T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).to be_valid
+    end
+
+    # 各期間は開始時刻を含み終了時刻を含まないため、境界が一致していても重ならない
+    it '登録期間の終了と希望提出期間の開始が同時刻でも有効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).to be_valid
+    end
+
+    it '登録期間の終了が開始より前だと無効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-07-31T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('登録期間の終了日時は開始日時より後にしてください')
+    end
+
+    it '登録期間の開始と終了が同時刻だと無効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('登録期間の終了日時は開始日時より後にしてください')
+    end
+
+    it '希望提出期間の終了が開始より前だと無効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-07T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('希望提出期間の終了日時は開始日時より後にしてください')
+    end
+
+    it '希望提出期間の開始と終了が同時刻だと無効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('希望提出期間の終了日時は開始日時より後にしてください')
+    end
+
+    it '希望提出期間の開始が登録期間の終了より前だと無効になる' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_starts_at: '2026-08-07T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('希望提出期間の開始日時は登録期間の終了日時以降にしてください')
+    end
+
+    it '日時が欠けていても順序のエラーは足さない' do
+      exchange = build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: nil,
+        wish_starts_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+
+      expect(exchange).not_to be_valid
+      expect(exchange.errors.full_messages)
+        .to contain_exactly('登録期間の終了日時を入力してください')
+    end
+  end
 end


### PR DESCRIPTION
## 概要

`Exchange` の登録期間と希望提出期間に、モデルレベルの整合性検証を入れました。
各期間の前後関係と、2つの期間が重ならないことを保証します。

あわせて次の2つを同梱しています。

- 日本語のエラーメッセージを置く先が無かったため、`rails-i18n` を入れて `default_locale` を `:ja` に
- NOT NULL の7カラムに `presence` バリデーションを追加

closes #6

## 判断したこと

- **重複の判定は `registration_ends_at <= wish_starts_at`**。仕様書 4. のとおり
  各期間は開始時刻を含み終了時刻を含まないため、境界が同時刻でも重ならない
- **`presence` と NOT NULL の二層にした**。`NotNullViolation` は例外なのでフォームに
  差し戻せない。一方で DB 制約を外すと `save(validate: false)` や `insert_all` で
  空が入る。spec も2本立てにし、どちらの層が抜けたのか切り分けられるようにした
- **`rails-i18n` を採用**。presence や numericality など Rails 標準のメッセージを
  自前で訳すと、バリデーションを足すたびに追随が要る
- **現在時刻を見ないため、基準時刻のキーワード引数は持たせていない**。カラム同士の比較のみ

## 完了条件

- [x] 各期間で開始 < 終了でなければ無効になる
- [x] 登録期間の終了 <= 希望提出期間の開始 でなければ無効になる（重複を許さない）
- [x] 境界がちょうど同時刻の場合に有効となることを spec で固定する
- [x] エラーメッセージが日本語で、どの期間が問題かが分かる

エラーメッセージの例:

- `登録期間の終了日時は開始日時より後にしてください`
- `希望提出期間の開始日時は登録期間の終了日時以降にしてください`
- `登録期間の終了日時を入力してください`

## 検証

- `bin/rspec` — 86 examples, 0 failures
- `bin/rubocop` — 違反なし
- `bin/ci` — 通過
- 各コミット単体で `bin/rspec` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)