### PR TITLE
rm を禁止から確認付きに変える

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,6 +59,7 @@
     "ask": [
       "Bash(git push:*)",
       "Bash(git reset --hard:*)",
+      "Bash(rm:*)",
       "Bash(gh pr merge:*)",
       "Bash(gh repo create:*)",
       "Bash(gh release:*)",
@@ -77,7 +78,6 @@
     ],
 
     "deny": [
-      "Bash(rm -rf:*)",
       "Bash(gh repo delete:*)",
       "Bash(gh issue delete:*)",
       "Bash(gh label delete:*)",


### PR DESCRIPTION
`.claude/settings.json` の `permissions` で、`rm` の扱いを `deny` から `ask` へ移す。

issue には紐づかない環境整備なので `closes` は書かない。

## なぜ

`deny` に置くと作業が止まる。スクラッチの掃除のような無害な用途まで実行できず、
そのたびに手で消すことになっていた。

一方で「コンテナ内だから安全」は成り立たない。

- `.devcontainer/compose.yaml` がリポジトリをホストからバインドマウントしている（`..:/workspaces/okuribon:cached`）
- `.devcontainer/devcontainer.json` は `~/.claude/CLAUDE.md` と `~/.claude/output-styles` を読み書き可で渡している

コンテナを捨てても直らないものが実際にあるため、無確認の `allow` にはしない。

## 対象を広げた理由

パターンは前方一致なので、`Bash(rm -rf:*)` は `rm -fr` `rm -Rf` `rm -r -f` を捕まえない。
これまでこれらは無確認で通っていた。禁止をやめる以上、抜け道のほうは塞いでおく。

`deny` を残したまま `ask` を足すことはできない。`deny > ask > allow` の順で効くため、
`rm -rf` という並びのときだけ従来どおり止まり、他は確認で通るという一貫性のない状態になる。

## 変わること

| コマンド | 変更前 | 変更後 |
|---|---|---|
| `rm -rf` | 実行不可 | 確認して実行 |
| `rm -fr` / `rm -Rf` / `rm -r` | 無確認で通過 | 確認して実行 |

差し引きで締まる方向の変更も含む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)