### PR TITLE
招待URL着地画面を作る

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# 招待URLを開いたときの着地画面。未参加の人と未ログインの人が最初に見る画面なので、
+# ログインを求めない。読み取りは全フェーズで開いている
+class InvitationsController < ApplicationController
+  def show
+    # 引けなければ 404。トークンが正しくないことと交換会が無いことを区別しない
+    @exchange = Exchange.find_by!(invite_token: params.expect(:token))
+
+    # ログインを挟んでもこの画面へ戻す。覚えるのはサーバーが見たパスだけで、
+    # 招待URLはこの GET でしか渡ってこない
+    store_return_to unless logged_in?
+  end
+end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -68,6 +68,14 @@ class Exchange < ApplicationRecord
     :awaiting_matching
   end
 
+  # 未ログインの人も着地画面を見るため、利用者がいない場合も答える。
+  # 呼ぶ側それぞれに nil の判定を書かせない
+  def participant?(user)
+    return false if user.nil?
+
+    participations.exists?(user:)
+  end
+
   def phase_name(at:)
     I18n.t(phase(at:), scope: 'exchange.phases')
   end

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,0 +1,62 @@
+<% content_for :title, "#{@exchange.name}への招待" %>
+
+<div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
+  <p class="text-[12px] font-medium tracking-wide text-ink-subtle">読書交換会への招待</p>
+  <h1 class="mt-2 text-[26px] font-bold leading-[1.45] text-ink"><%= @exchange.name %></h1>
+
+  <p class="mt-2 text-[13.5px] leading-[1.9] text-ink-muted">
+    <%= @exchange.owner.display_name %>さんが主催しています。
+    現在<span class="tabular"><%= @exchange.participations.count %>人</span>が参加しています。
+  </p>
+
+  <% if @exchange.description.present? %>
+    <p class="mt-6 whitespace-pre-line text-[14.5px] leading-[1.95] text-ink">
+      <%= @exchange.description %>
+    </p>
+  <% end %>
+
+  <div class="mt-8 border-t border-line pt-8">
+    <h2 class="text-[15px] font-bold text-ink">日程</h2>
+
+    <dl class="mt-4 flex flex-col gap-3">
+      <%# 登録の締切は希望提出期間の開始でもある。片方だけ書くと、締切のあとに
+          何が始まるのかが読み取れない %>
+      <% [['登録期間の開始', @exchange.registration_starts_at],
+          ['登録の締切（＝希望提出期間の開始）', @exchange.registration_ends_at],
+          ['希望提出の締切', @exchange.wish_ends_at]].each do |label, at| %>
+        <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+          <dt class="text-[13px] text-ink-muted"><%= label %></dt>
+          <dd class="tabular text-[14.5px] font-medium text-ink"><%= l at, format: :schedule %></dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+
+  <%# ログイン済みの人が押す参加のボタンは、参加処理そのものと一緒に #16 で足す。
+      言うことが無いときは区切り線ごと出さない %>
+  <% if @exchange.participant?(current_user) %>
+    <div class="mt-8 border-t border-line pt-8">
+      <%# 交換会トップ（#19）が入ったら、この画面に留めずトップへ送る %>
+      <p class="text-[14.5px] font-medium text-success">この交換会にはすでに参加しています。</p>
+    </div>
+  <% elsif !@exchange.writable?(:participation, at: requested_at) %>
+    <div class="mt-8 border-t border-line pt-8">
+      <p class="text-[14.5px] font-medium text-accent">参加を受け付ける期間は終わりました。</p>
+      <p class="mt-2 text-[13px] leading-[1.85] text-ink-muted">
+        登録の締切を過ぎると参加できません。主催者にお問い合わせください。
+      </p>
+    </div>
+  <% elsif !logged_in? %>
+    <div class="mt-8 border-t border-line pt-8">
+      <%# 認証開始は POST に限る。GET で踏めると、外部サイトに置いた
+          画像やリンクだけで認証をやり直させられる %>
+      <%= button_to '参加する', '/auth/google_oauth2', method: :post,
+                    class: 'cursor-pointer rounded-[5px] bg-accent px-6 py-3.5 text-[14.5px] ' \
+                           'font-medium text-paper hover:bg-accent-hover' %>
+
+      <p class="mt-3 text-[12px] leading-[1.85] text-ink-subtle">
+        Google でログインすると参加できます。受け取るのは表示名とアイコンだけです。
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  time:
+    formats:
+      # 日程の表示。rails-i18n の :long は秒まで出るため、分までの書式を別に持つ
+      schedule: "%Y年%-m月%-d日 %H:%M"
   exchange:
     phases:
       preparing: 準備中

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,12 @@ Rails.application.routes.draw do
   # 外部サイトに置いたリンクや画像だけでログアウトさせられてしまう
   delete '/logout' => 'sessions#destroy', as: :logout
 
-  # 一覧（#18）・トップ（#19）・招待URL着地（#15）は、それぞれの issue で足す
+  # 一覧（#18）・トップ（#19）は、それぞれの issue で足す
   resources :exchanges, only: [:new, :create, :edit, :update]
+
+  # 招待URL。交換会の id ではなく招待トークンで引く。
+  # id で引けると、番号を数えるだけで招待されていない交換会に着地できてしまう
+  get '/invitations/:token' => 'invitations#show', as: :invitation
 
   # 交換会一覧（#18）が入るまでの暫定でログイン画面を置く
   root 'sessions#new'

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Exchange do
 
   # 空きを許すとどのフェーズにも属さない時間ができるため、両者は同時刻でなければならない。
   # カラムに分けて等値を検証するのではなく、導出して二重管理をなくす
-  describe '希望提出期間の開始' do
+  describe '#wish_starts_at' do
     it '登録期間の終了と同じ時刻になる' do
       exchange = build(:exchange, registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone)
 
@@ -166,7 +166,7 @@ RSpec.describe Exchange do
     end
   end
 
-  describe 'フェーズ' do
+  describe '#phase' do
     let!(:exchange) do
       build(
         :exchange,
@@ -265,30 +265,39 @@ RSpec.describe Exchange do
       expect(at_list.map { |at| exchange.phase(at: at.in_time_zone) })
         .to all(be_in(Exchange::PHASES))
     end
+  end
 
-    describe '表示名' do
-      it '基準時刻のフェーズの表示名を日本語で返す' do
-        expect(exchange.phase_name(at: '2026-07-25T00:00:00+09:00'.in_time_zone)).to eq('準備中')
-        expect(exchange.phase_name(at: '2026-08-04T00:00:00+09:00'.in_time_zone)).to eq('登録期間')
-        expect(exchange.phase_name(at: '2026-08-11T00:00:00+09:00'.in_time_zone)).to eq('希望提出期間')
-        expect(exchange.phase_name(at: '2026-08-20T00:00:00+09:00'.in_time_zone)).to eq('マッチング実行待ち')
-      end
+  describe '#phase_name' do
+    let!(:exchange) do
+      build(
+        :exchange,
+        registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+        registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+        wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone
+      )
+    end
 
-      it 'マッチング実行日時が入っていれば結果公開になる' do
-        exchange.matched_at = '2026-08-16T00:00:00+09:00'.in_time_zone
+    it '基準時刻のフェーズの表示名を日本語で返す' do
+      expect(exchange.phase_name(at: '2026-07-25T00:00:00+09:00'.in_time_zone)).to eq('準備中')
+      expect(exchange.phase_name(at: '2026-08-04T00:00:00+09:00'.in_time_zone)).to eq('登録期間')
+      expect(exchange.phase_name(at: '2026-08-11T00:00:00+09:00'.in_time_zone)).to eq('希望提出期間')
+      expect(exchange.phase_name(at: '2026-08-20T00:00:00+09:00'.in_time_zone)).to eq('マッチング実行待ち')
+    end
 
-        expect(exchange.phase_name(at: '2026-08-20T00:00:00+09:00'.in_time_zone)).to eq('結果公開')
-      end
+    it 'マッチング実行日時が入っていれば結果公開になる' do
+      exchange.matched_at = '2026-08-16T00:00:00+09:00'.in_time_zone
 
-      it '基準時刻を省略すると呼べない' do
-        expect { exchange.phase_name }.to raise_error(ArgumentError)
-      end
+      expect(exchange.phase_name(at: '2026-08-20T00:00:00+09:00'.in_time_zone)).to eq('結果公開')
+    end
+
+    it '基準時刻を省略すると呼べない' do
+      expect { exchange.phase_name }.to raise_error(ArgumentError)
     end
   end
 
   # 「登録期間中のみ本を登録できる」といった判定を、書き込み口ごとの手書きにしない。
   # 許可されるフェーズは spec.md 4. フェーズの表と補足に対応する
-  describe '書き込みの可否' do
+  describe '#writable?' do
     let!(:exchange) do
       build(
         :exchange,
@@ -440,7 +449,7 @@ RSpec.describe Exchange do
     end
   end
 
-  describe '参加しているかどうか' do
+  describe '#participant?' do
     let!(:exchange) { create(:exchange) }
     let!(:user) { create(:user) }
 

--- a/spec/models/exchange_spec.rb
+++ b/spec/models/exchange_spec.rb
@@ -440,6 +440,32 @@ RSpec.describe Exchange do
     end
   end
 
+  describe '参加しているかどうか' do
+    let!(:exchange) { create(:exchange) }
+    let!(:user) { create(:user) }
+
+    it '参加していれば true になる' do
+      create(:participation, exchange:, user:)
+
+      expect(exchange.participant?(user)).to be(true)
+    end
+
+    it '参加していなければ false になる' do
+      expect(exchange.participant?(user)).to be(false)
+    end
+
+    it '別の交換会への参加は数えない' do
+      create(:participation, user:)
+
+      expect(exchange.participant?(user)).to be(false)
+    end
+
+    # 未ログインの人は着地画面をそのまま見る。呼ぶ側で nil を弾かせない
+    it '利用者がいなければ false になる' do
+      expect(exchange.participant?(nil)).to be(false)
+    end
+  end
+
   describe '乱数シード' do
     # 与えたシードでマッチングを回し、結果を比較できる形にして返す
     def matching_result_for(seed)

--- a/spec/requests/invitations_controller_spec.rb
+++ b/spec/requests/invitations_controller_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InvitationsController do
+  let!(:owner) { create(:user, display_name: '主催 太郎') }
+  let!(:exchange) do
+    create(:exchange, owner:,
+                      name: '夏の交換会',
+                      description: 'Kindle のみ。1000円前後を目安に。',
+                      registration_starts_at: '2026-08-10T10:00:00+09:00'.in_time_zone,
+                      registration_ends_at: '2026-08-24T10:00:00+09:00'.in_time_zone,
+                      wish_ends_at: '2026-09-07T10:00:00+09:00'.in_time_zone)
+  end
+
+  describe '#show' do
+    # 存在しない交換会と、招待されていない交換会を見分けられないようにする
+    it '無効なトークンでは見つからない' do
+      get invitation_path('deadbeefdeadbeef')
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # 招待された人はまだログインしていない。何の集まりかを見てから決められるようにする
+    describe '交換会の概要' do
+      before { get invitation_path(exchange.invite_token) }
+
+      it '未ログインでも開ける' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '交換会名と概要が出る' do
+        expect(response.body).to include('夏の交換会')
+        expect(response.body).to include('Kindle のみ。1000円前後を目安に。')
+      end
+
+      it '主催者名が出る' do
+        expect(response.body).to include('主催 太郎')
+      end
+
+      it '参加者数が出る' do
+        create_list(:participation, 2, exchange:)
+
+        get invitation_path(exchange.invite_token)
+
+        expect(response.body).to include('2人')
+      end
+
+      # UTC で描かれると9時間ずれた日程が出て、参加を決める判断そのものが狂う
+      it '各期間の日程が JST で出る' do
+        expect(response.body).to include('2026年8月10日 10:00')
+        expect(response.body).to include('2026年8月24日 10:00')
+        expect(response.body).to include('2026年9月7日 10:00')
+      end
+    end
+
+    describe '未ログインのとき' do
+      before { get invitation_path(exchange.invite_token) }
+
+      it '「参加する」でログインへ送る' do
+        expect(response.body).to include('参加する')
+        expect(response.body).to include('action="/auth/google_oauth2"')
+      end
+
+      # 戻り先はサーバーが見たパスだけを覚える。パラメータや Referer から
+      # 受け取ると、もっともらしい招待リンクで認証直後に外部サイトへ落とせる
+      it 'ログインしたら招待URLへ戻す' do
+        log_in_as(create(:user))
+
+        expect(response).to redirect_to(invitation_path(exchange.invite_token))
+      end
+    end
+
+    # 交換会トップ（#19）が入ったら、この画面には留めずトップへ送る
+    describe '参加済みのとき' do
+      let!(:participant) { create(:user) }
+
+      before do
+        create(:participation, exchange:, user: participant)
+        log_in_as(participant)
+
+        get invitation_path(exchange.invite_token)
+      end
+
+      it '参加済みであることが分かる' do
+        expect(response.body).to include('すでに参加しています')
+      end
+
+      it '参加のボタンを出さない' do
+        expect(response.body).not_to include('参加する')
+      end
+    end
+
+    # 参加できるのは登録期間の締切まで。判定はサーバーが受けた時刻で行い、
+    # 可否の条件は Exchange::WRITABLE_PHASES に集約する
+    describe '参加を受け付ける期間' do
+      it '準備中でも参加できる' do
+        travel_to '2026-08-01T10:00:00+09:00' do
+          get invitation_path(exchange.invite_token)
+
+          expect(response.body).to include('参加する')
+        end
+      end
+
+      # 各期間は終了時刻を含まない。締切ちょうどはもう登録期間の外になる
+      it '登録の締切ちょうどからは参加できない' do
+        travel_to '2026-08-24T10:00:00+09:00' do
+          get invitation_path(exchange.invite_token)
+
+          expect(response.body).to include('参加を受け付ける期間は終わりました')
+          expect(response.body).not_to include('参加する')
+        end
+      end
+
+      it '締切を過ぎていても交換会の概要は見える' do
+        travel_to '2026-09-01T10:00:00+09:00' do
+          get invitation_path(exchange.invite_token)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('夏の交換会')
+        end
+      end
+    end
+
+    # 招待URLを知っているだけの人が開く画面なので、参加者向けの情報を一切載せない。
+    # とくにギフトコードは、一度見えたら取り消せない
+    describe '載せない情報' do
+      it '本の情報とギフトコードが含まれない' do
+        book = create(:book, title: '吾輩は猫である', gift_code: 'GIFTCODE12345678',
+                             participation: create(:participation, exchange:))
+
+        get invitation_path(exchange.invite_token)
+
+        expect(response.body).not_to include(book.title)
+        expect(response.body).not_to include(book.gift_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
招待トークン付きの URL を開いたときの着地画面を作りました。

`GET /invitations/:token` で交換会を招待トークンから引き、交換会名・概要・主催者名・参加者数・各期間の日程を見せます。交換会の id では引きません。id で引けると、番号を数えるだけで招待されていない交換会に着地できてしまうためです。引けなければ 404 を返し、トークンが違うことと交換会が存在しないことを区別しません。

## 完了条件

- [x] 未ログインでも交換会の概要が見え、「参加する」でログインへ誘導される
- [x] 無効なトークンでは 404 になる
- [x] 登録期間の締切を過ぎている場合は参加できない旨が表示され、ボタンが出ない
- [x] この画面に本の情報やギフトコードが含まれない
- [ ] 参加済みの人が開くと交換会トップへ送られる

## 満たしていない完了条件

**参加済みの人が開くと交換会トップへ送られる** — 交換会トップ（#19）がまだ無いため、送り先がありません。代わりに着地画面へ「この交換会にはすでに参加しています。」と出しています。#19 が入った時点でリダイレクトへ置き換えます。ビューにその旨のコメントを残しました。

## 併せて決めたこと

**ログイン済み・未参加の人には参加のボタンを出しません。** 押し先になる参加処理は #16 の担当で、まだ存在しないためです。ボタンだけ先に置くと、押しても動かないものが main に残ります。この画面で参加まで完結するのは #16 が入ってからになります。

## そのほか

- 参加を受け付けるかどうかは `Exchange#writable?(:participation, at:)` で判定しています。「登録期間の締切まで」という条件を画面側に書き写すと、口ごとに食い違うためです。締切ちょうどが期間の外になることを spec で固定しました
- 未ログインで開いたときに戻り先を覚え、ログイン後に招待URLへ戻します。覚えるのはサーバーが見たパスだけで、招待URLはこの GET でしか渡ってきません（`docs/spec.md` 11）
- `Exchange#participant?` を足しました。#16 と #19 でも使います
- 日程の表示用に `time.formats.schedule` を足しました。rails-i18n の `:long` は秒まで出て、日程を並べたときに読みにくいためです

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)