### PR TITLE
本の一覧を作る

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BooksController < ApplicationController
+  before_action :require_login
+
+  # 本の一覧。交換会トップと同じく参加から引くので、参加していなければ見つからない。
+  # 読み取りは全フェーズで開いており、止めるのは書き込みだけ（docs/spec.md 4. フェーズ）。
+  # 登録順に並べる。開くたびにカードの位置が入れ替わると、
+  # 前に見た本を毎回探し直すことになる
+  def index
+    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
+    @exchange = @participation.exchange
+    # 冊数の表示と空の判定にも同じ本を使うので、その場で読み込む。
+    # 関連のままだと、並べる前に COUNT と EXISTS が別々に飛ぶ
+    @books = @exchange.books.includes(:registrant).order(:created_at, :id).load
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,6 +4,10 @@ class Book < ApplicationRecord
   belongs_to :participation
   has_one :exchange, through: :participation
 
+  # 登録者。一覧のカードに名前を出すため、参加を経由せず引けるようにする。
+  # 参加は交換会ごとに作られるので、本から見た利用者は必ず1人に定まる
+  has_one :registrant, through: :participation, source: :user
+
   has_many :wishes, dependent: :destroy
   has_one :assignment, dependent: :destroy
 

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,0 +1,55 @@
+<% content_for :title, "#{@exchange.name}の本" %>
+
+<div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
+  <%# 戻り先は交換会トップだけにする。この画面へ来る入口がそこしかない %>
+  <p class="text-[12px]"><%= link_to @exchange.name, exchange_path(@exchange) %></p>
+
+  <%# 狭い画面では見出しと冊数が縦に折り返る %>
+  <div class="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-2">
+    <h1 class="text-[26px] font-bold leading-[1.45] text-ink">本の一覧</h1>
+    <span class="tabular text-[13px] text-ink-muted"><%= @books.size %>冊</span>
+  </div>
+
+  <% if @books.empty? %>
+    <%# 白紙で返すと、壊れているのかまだ誰も登録していないのか区別がつかない。
+        登録の導線は #21 で足すので、ここでは待てば埋まることだけを伝える %>
+    <div class="mt-6 rounded-[5px] border border-line bg-paper px-5 py-6">
+      <p class="text-[14.5px] font-medium text-ink">まだ本は登録されていません。</p>
+      <p class="mt-2 text-[13px] leading-[1.85] text-ink-muted">
+        誰かが登録すると、ここに並びます。
+      </p>
+    </div>
+  <% else %>
+    <ul class="mt-6 flex flex-col gap-3">
+      <% @books.each do |book| %>
+        <li class="rounded-[5px] border border-line bg-paper px-5 py-5">
+          <%# 誰が登録したかは参加者全員に見える（docs/spec.md 8.）。
+              狭い画面ではタイトルと登録者名が縦に折り返る %>
+          <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <h2 class="text-[17px] font-bold leading-[1.5] text-ink"><%= book.title %></h2>
+            <span class="text-[12px] text-ink-subtle"><%= book.registrant.display_name %></span>
+          </div>
+
+          <%# あらすじは冒頭だけ。数行を丸ごと並べると、一覧をざっと眺められなくなる %>
+          <% if book.summary.present? %>
+            <p class="mt-3 text-[13.5px] leading-[1.9] text-ink-muted">
+              <%= truncate(book.summary, length: 80, omission: '…') %>
+            </p>
+          <% end %>
+
+          <%# 読み比べるのがこの画面の目的なので、おすすめポイントは全文を出す。
+              本の詳細（#23）がまだ無く、ここで切ると続きを読む先がどこにも無い。
+              地の上に一段沈めて、あらすじと役割が違うことを面で分ける %>
+          <% if book.recommendation.present? %>
+            <div class="mt-4 rounded-[3px] bg-surface-sunken px-4 py-3.5">
+              <p class="text-[12px] text-ink-subtle">おすすめポイント</p>
+              <%# 改行を活かすので、タグの内側で折り返さない。
+                  pre-line はタグ直後の改行も1行として残す %>
+              <p class="mt-1.5 whitespace-pre-line text-[14px] leading-[1.95] text-ink"><%= book.recommendation %></p>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/exchanges/show.html.erb
+++ b/app/views/exchanges/show.html.erb
@@ -55,7 +55,15 @@
     <% end %>
   </dl>
 
-  <%# 本の一覧（#22）、結果画面（#32）、主催者管理画面（#36）への導線は、
+  <%# 本を選ぶのがこのツールの中心なので、導線は面で押させる。
+      読み取りは全フェーズで開いているため、フェーズでは出し分けない %>
+  <div class="mt-8 border-t border-line pt-8">
+    <%= link_to '本の一覧を見る', exchange_books_path(@exchange),
+                class: 'block rounded-[5px] border border-line-strong bg-paper px-5 py-4 ' \
+                       'text-center text-[14.5px] font-medium text-ink no-underline hover:bg-paper-hover' %>
+  </div>
+
+  <%# 結果画面（#32）、主催者管理画面（#36）への導線は、
       それぞれの画面が入るときにここへ足す。
       「今なにをすべきか」の文言は #29 で足す %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,11 @@ Rails.application.routes.draw do
   # 外部サイトに置いたリンクや画像だけでログアウトさせられてしまう
   delete '/logout' => 'sessions#destroy', as: :logout
 
-  resources :exchanges, only: [:index, :show, :new, :create, :edit, :update]
+  # 本は必ずどれか1つの交換会に属し、単独では意味を持たない。
+  # 交換会の下に置くと、参加しているかどうかの判定を親から引ける
+  resources :exchanges, only: [:index, :show, :new, :create, :edit, :update] do
+    resources :books, only: [:index]
+  end
 
   # 招待URL。交換会の id ではなく招待トークンで引く。
   # id で引けると、番号を数えるだけで招待されていない交換会に着地できてしまう

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BooksController do
+  let!(:user) { create(:user) }
+  let!(:exchange) { create(:exchange, name: '夏の交換会') }
+  let!(:participation) { create(:participation, user:, exchange:) }
+
+  before { log_in_as(user) }
+
+  describe '#index' do
+    def open_list
+      get exchange_books_path(exchange)
+    end
+
+    # 登録者を名前で撒くための入れ物。参加を伴わない本は作れない
+    def book_by(display_name, **attributes)
+      registrant = create(:participation, exchange:, user: create(:user, display_name:))
+      create(:book, participation: registrant, **attributes)
+    end
+
+    it '参加者は開ける' do
+      open_list
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # 選ぶ材料は全員の本。自分の登録した本だけでは読み比べにならない
+    it '全員の本が並ぶ' do
+      create(:book, participation:, title: '自分の本')
+      book_by('佐藤 花子', title: '他の人の本')
+
+      open_list
+
+      expect(response.body).to include('自分の本')
+      expect(response.body).to include('他の人の本')
+    end
+
+    it '誰が登録したかが分かる' do
+      book_by('佐藤 花子')
+
+      open_list
+
+      expect(response.body).to include('佐藤 花子')
+    end
+
+    # 数行のテキストを丸ごと並べると、一覧をざっと眺められなくなる
+    it '長いあらすじは冒頭だけ出る' do
+      book_by('佐藤 花子', summary: "#{'あ' * 200}ここは切られる")
+
+      open_list
+
+      expect(response.body).to include('あ' * 50)
+      expect(response.body).not_to include('ここは切られる')
+    end
+
+    it '短いあらすじはそのまま出る' do
+      book_by('佐藤 花子', summary: 'ある町に住む青年が、古い書店で一冊の本と出会う。')
+
+      open_list
+
+      expect(response.body).to include('ある町に住む青年が、古い書店で一冊の本と出会う。')
+    end
+
+    # 読み比べがこの画面の目的。本の詳細（#23）がまだ無いので、
+    # ここで切ると続きを読む先がどこにも無い
+    it 'おすすめポイントは全文出る' do
+      book_by('佐藤 花子', recommendation: "#{'ぜ' * 200}最後まで読める")
+
+      open_list
+
+      expect(response.body).to include('最後まで読める')
+    end
+
+    # 見えるのは登録した本人と、成立後の受取人だけ。一覧はどちらの経路でもない
+    it 'ギフトコードが含まれない' do
+      create(:book, participation:, gift_code: 'MYOWNGIFTCODE')
+      book_by('佐藤 花子', gift_code: 'OTHERGIFTCODE')
+
+      open_list
+
+      expect(response.body).not_to include('MYOWNGIFTCODE')
+      expect(response.body).not_to include('OTHERGIFTCODE')
+    end
+
+    # 開くたびにカードの位置が入れ替わると、前に見た本を探し直すことになる
+    it '登録順に並ぶ' do
+      create(:book, participation:, title: '先に登録した本')
+      create(:book, participation:, title: 'あとで登録した本')
+
+      open_list
+
+      expect(response.body.index('先に登録した本')).to be < response.body.index('あとで登録した本')
+    end
+
+    # 白紙で返すと、壊れているのかまだ誰も登録していないのか区別がつかない
+    it '1冊も登録されていなければその旨を出す' do
+      open_list
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('まだ本は登録されていません')
+    end
+
+    # 403 だと、招待されていない交換会の実在が URL を試すだけで確かめられる
+    it '参加していなければ見つからない' do
+      log_in_as(create(:user))
+
+      open_list
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # 主催者は必ず参加者を兼ねるので、自分の交換会の一覧を開ける
+    it '主催者も開ける' do
+      owned = create(:exchange, owner: user)
+
+      get exchange_books_path(owned)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'ログインしていなければログイン画面へ送る' do
+      log_out
+
+      open_list
+
+      expect(response).to redirect_to(login_path)
+    end
+
+    # 読み取りは全フェーズで開いている。止めるのは書き込みだけ
+    # （docs/spec.md 4. フェーズ）
+    [
+      ['準備中', '2026-07-25T00:00:00+09:00'],
+      ['登録期間', '2026-08-04T00:00:00+09:00'],
+      ['希望提出期間', '2026-08-11T00:00:00+09:00'],
+      ['マッチング実行待ち', '2026-08-20T00:00:00+09:00'],
+    ].each do |phase, now|
+      it "#{phase}でも開ける" do
+        exchange.update!(registration_starts_at: '2026-08-01T00:00:00+09:00'.in_time_zone,
+                         registration_ends_at: '2026-08-08T00:00:00+09:00'.in_time_zone,
+                         wish_ends_at: '2026-08-15T00:00:00+09:00'.in_time_zone)
+
+        travel_to(now) { open_list }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it '結果公開でも開ける' do
+      exchange.update!(matched_at: 1.day.ago)
+
+      open_list
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/exchanges_controller_spec.rb
+++ b/spec/requests/exchanges_controller_spec.rb
@@ -303,6 +303,13 @@ RSpec.describe ExchangesController do
       end
     end
 
+    # 導線が無いと、URL を直打ちしないと開けない画面になる
+    it '本の一覧への導線がある' do
+      open_top
+
+      expect(response.body).to include(exchange_books_path(exchange))
+    end
+
     # 見えるのは登録した本人と、成立後の受取人だけ。トップはどちらの経路でもない
     it 'ギフトコードが含まれない' do
       create(:book, participation:, gift_code: 'MYOWNGIFTCODE')


### PR DESCRIPTION
登録された本をカード形式で並べる画面を作りました。読み取りだけで、編集・削除の導線は行き先であるフォームができる #21 で足します。

closes #22

## 変更点

- `GET /exchanges/:exchange_id/books` を追加。交換会トップと同じく参加から引くので、参加していなければ 404 になる
- 読み取りは全フェーズで開ける（`docs/spec.md` 4.「止めるのは書き込みだけ」）
- 並び順は登録順に固定。開くたびにカードの位置が入れ替わらないようにする
- 交換会トップに一覧への導線を置いた
- `Book#registrant` を足し、`includes` で登録者名を引くときの N+1 を避けた

## 完了条件

- [x] 全員の本が並び、誰が登録したかが分かる
- [x] 交換会トップからこの画面を開ける
- [x] カードのレスポンスにギフトコードが一切含まれない
- [x] 本が1冊も登録されていない場合の表示がある
- [x] おすすめポイントが読み比べられる程度に見えつつ、一覧をざっと眺められる
- [x] 参加していないユーザーが開けない
- [x] モバイル幅で崩れない

## 判断したこと

**おすすめポイントは切らずに全文を出す。** 読み比べがこの画面の目的であり、本の詳細（#23）がまだ無いため、ここで切ると続きを読む先がどこにも無いためです。あらすじのほうは冒頭80字までにして、一覧をざっと眺められるようにしました。詳細が入ったら、おすすめポイントを頭打ちにする選択肢も出てきます。

## 検証

`bin/rspec`（378 examples, 0 failures）、`bin/rubocop`、`bin/ci` を通しています。

モバイル幅は system spec の仕組みがまだ無いため、テンプレートを静的に描き出して 375px と 700px で目視確認しました。長いタイトルと長い表示名が折り返ることを見ています。

なお、`whitespace-pre-line` を当てた段落でタグの内側を改行すると、その改行が1行として残ります。同じ書き方が `app/views/exchanges/show.html.erb` の概要と `app/views/invitations/show.html.erb` にもありますが、この PR の範囲外なので触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)