### PR TITLE
本の登録・編集・削除を実装する

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -34,7 +34,8 @@ class BooksController < ApplicationController
     @book = @participation.books.build(book_params)
 
     if @book.save
-      redirect_to exchange_books_path(@exchange), notice: t('book.flash.created')
+      redirect_to after_create_path,
+                  notice: t('book.flash.created', title: @book.title, count: @participation.books.count)
     else
       render :new, status: :unprocessable_content
     end
@@ -68,6 +69,14 @@ class BooksController < ApplicationController
   # フェーズの判定対象。PhaseGuard から呼ばれる
   def current_exchange
     @exchange
+  end
+
+  # 「登録して、続けてもう1冊」で来たときだけフォームへ戻す。
+  # 何冊でも登録できるので、毎回一覧を経由させると1冊ごとに2画面を往復することになる
+  def after_create_path
+    return new_exchange_book_path(@exchange) if params[:continue].present?
+
+    exchange_books_path(@exchange)
   end
 
   # 自分の本だけを引く。他人の本は見つからないことにする。

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,17 +1,83 @@
 # frozen_string_literal: true
 
 class BooksController < ApplicationController
+  include PhaseGuard
+
   before_action :require_login
+  before_action :set_participation
+
+  # フォームを開く時点で止める。押しても通らない画面を開かせても仕方がない。
+  # only: ではなく except: にして、既定を「止める」に倒す。
+  # 書き込みのアクションが増えたときに、書き忘れが素通りにならない。
+  # 読み取りは全フェーズで開くので、詳細（#23）を足すときはここに並べる
+  guard_phase :book, except: [:index]
 
   # 本の一覧。交換会トップと同じく参加から引くので、参加していなければ見つからない。
   # 読み取りは全フェーズで開いており、止めるのは書き込みだけ（docs/spec.md 4. フェーズ）。
   # 登録順に並べる。開くたびにカードの位置が入れ替わると、
   # 前に見た本を毎回探し直すことになる
   def index
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
-    @exchange = @participation.exchange
     # 冊数の表示と空の判定にも同じ本を使うので、その場で読み込む。
     # 関連のままだと、並べる前に COUNT と EXISTS が別々に飛ぶ
     @books = @exchange.books.includes(:registrant).order(:created_at, :id).load
+  end
+
+  def new
+    @book = @participation.books.build
+  end
+
+  def edit
+    @book = own_book
+  end
+
+  def create
+    @book = @participation.books.build(book_params)
+
+    if @book.save
+      redirect_to exchange_books_path(@exchange), notice: t('book.flash.created')
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    @book = own_book
+
+    if @book.update(book_params)
+      redirect_to exchange_books_path(@exchange), notice: t('book.flash.updated')
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    own_book.destroy!
+
+    redirect_to exchange_books_path(@exchange), notice: t('book.flash.destroyed')
+  end
+
+  private
+
+  # 交換会は参加から引く。参加していなければ見つからない。
+  # 読み取りと書き込みで入口を分けると、片方だけ緩む
+  def set_participation
+    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
+    @exchange = @participation.exchange
+  end
+
+  # フェーズの判定対象。PhaseGuard から呼ばれる
+  def current_exchange
+    @exchange
+  end
+
+  # 自分の本だけを引く。他人の本は見つからないことにする。
+  # 403 を返すと、その id の本が実在することを URL を試すだけで確かめられる
+  def own_book
+    @participation.books.find(params.expect(:id))
+  end
+
+  # 登録者は参加から決める。送られてきた participation_id は受け取らない
+  def book_params
+    params.expect(book: [:title, :summary, :url, :recommendation, :gift_code])
   end
 end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BooksHelper
+  # 削除の確認文。一覧と編集フォームの2か所から押せるので、文言をここへ集める。
+  # 消えるのは本だけではない。取得枠が1つ減り、その本への他の人の希望も一緒に消える
+  def book_deletion_confirm(book, slots:)
+    t('book.deletion_confirm', title: book.title, before: slots, after: slots - 1)
+  end
+end

--- a/app/javascript/controllers/counter_controller.js
+++ b/app/javascript/controllers/counter_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 入力中の文字数を出す。上限ではなく目安なので、超えても止めず色も変えない。
+// 字数で切ると、書きたいだけ書けなくなる
+export default class extends Controller {
+  static targets = ["field", "output"]
+
+  count() {
+    this.outputTarget.textContent = this.fieldTarget.value.length
+  }
+}

--- a/app/javascript/controllers/reveal_controller.js
+++ b/app/javascript/controllers/reveal_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 伏せ字の入力欄を一時的に開く。ギフトコードは肩越しに覗かれるだけで渡ってしまうため、
+// 既定は伏せたままにし、確かめたいときだけ開く。
+// 開いた状態は保存しない。画面を移れば必ず伏せ字に戻る
+export default class extends Controller {
+  static targets = ["field", "button"]
+
+  toggle() {
+    const hidden = this.fieldTarget.type === "password"
+
+    this.fieldTarget.type = hidden ? "text" : "password"
+    this.buttonTarget.textContent = hidden ? "隠す" : "表示"
+  }
+}

--- a/app/javascript/controllers/reveal_controller.js
+++ b/app/javascript/controllers/reveal_controller.js
@@ -2,14 +2,45 @@ import { Controller } from "@hotwired/stimulus"
 
 // 伏せ字の入力欄を一時的に開く。ギフトコードは肩越しに覗かれるだけで渡ってしまうため、
 // 既定は伏せたままにし、確かめたいときだけ開く。
-// 開いた状態は保存しない。画面を移れば必ず伏せ字に戻る
+//
+// 開きっぱなしにはしない。入力中の画面はそのまま放置されやすく、
+// 席を立っている間に読まれる。一定時間で自ら伏せ字へ戻す。
+// 開いた状態は保存しないので、画面を移れば必ず伏せ字に戻る
 export default class extends Controller {
-  static targets = ["field", "button"]
+  static targets = ["field", "button", "warning"]
+  static values = { revertAfter: { type: Number, default: 10000 } }
+
+  disconnect() {
+    this.#clearTimer()
+  }
 
   toggle() {
-    const hidden = this.fieldTarget.type === "password"
+    this.fieldTarget.type === "password" ? this.show() : this.hide()
+  }
 
-    this.fieldTarget.type = hidden ? "text" : "password"
-    this.buttonTarget.textContent = hidden ? "隠す" : "表示"
+  show() {
+    this.fieldTarget.type = "text"
+    this.buttonTarget.textContent = "隠す"
+    this.#toggleWarning(true)
+
+    this.#clearTimer()
+    this.timer = setTimeout(() => this.hide(), this.revertAfterValue)
+  }
+
+  hide() {
+    this.fieldTarget.type = "password"
+    this.buttonTarget.textContent = "表示"
+    this.#toggleWarning(false)
+
+    this.#clearTimer()
+  }
+
+  #toggleWarning(shown) {
+    if (this.hasWarningTarget) this.warningTarget.classList.toggle("hidden", !shown)
+  }
+
+  #clearTimer() {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = null
   }
 }

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -16,6 +16,9 @@ class Book < ApplicationRecord
   # 値で検索する用事も無いので、既定の非決定的暗号化のままにする
   encrypts :gift_code
 
+  # NOT NULL のカラムは presence でも弾く。DB の例外ではなくフォームのエラーとして返すため
+  validates :title, :gift_code, presence: true
+
   # ギフトコードが見えるのは「登録した本人（常時）」と「受け取った人（結果公開後）」の
   # 2者のみ。主催者に特権はない（docs/spec.md 8. 情報の可視性ルール）。
   # 伏せ字の出し分けと gift_code_for を同じ規則から引く。片方だけを直すと、

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,4 +1,7 @@
-<%= form_with model: [exchange, book], class: 'flex flex-col gap-8' do |f| %>
+<%# 並びは仕様の順ではなく「書く気になる順」にする（ビジュアルガイド 6.4）。
+    タイトル → おすすめポイント（主役）→ あらすじと URL（補足）→ ギフトコード（機微）。
+    任意のあらすじを後ろに置き、書けなくても先へ進めるようにする %>
+<%= form_with model: [exchange, book], class: 'flex flex-col gap-6' do |f| %>
   <% if book.errors.any? %>
     <div class="rounded-[5px] border border-accent bg-accent-soft px-5 py-4">
       <p class="text-[13.5px] font-medium text-accent">入力を確認してください</p>
@@ -10,57 +13,99 @@
     </div>
   <% end %>
 
-  <div class="flex flex-col gap-5">
-    <div class="flex flex-col gap-1.5">
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline gap-2">
       <%= f.label :title, class: 'text-[13px] font-medium text-ink' %>
-      <%= f.text_field :title, required: true,
-                       class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+      <span class="text-[11px] text-accent">必須</span>
     </div>
+    <%= f.text_field :title, required: true, placeholder: '例：波打ち際の観測所',
+                     class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3.5 text-[15px] text-ink' %>
+  </div>
 
+  <%# 専用の面を持つのはここだけ。朱の左罫と大きなラベルで、任意でありながら
+      主役であることを面で示す。他の入力欄の2倍の高さを取る %>
+  <div class="flex flex-col gap-4 rounded-[5px] border border-accent-soft border-l-[3px] border-l-accent
+              bg-paper px-6 py-6" data-controller="counter">
     <div class="flex flex-col gap-1.5">
-      <%= f.label :url, class: 'text-[13px] font-medium text-ink' %>
-      <p class="text-[12px] leading-[1.85] text-ink-subtle">
-        ストアの商品ページ。表紙や価格を確かめる先になります。
+      <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <%= f.label :recommendation, class: 'text-[17px] font-bold text-ink' %>
+        <span class="text-[11.5px] text-ink-subtle">任意だけれど、ここが主役</span>
+      </div>
+      <p class="text-[13px] leading-[1.85] text-ink-muted">
+        みんながいちばん読むのはここです。あらすじは要りません。<b class="font-bold text-ink">あなたがこの本をどう読んだか</b>を、思い出したままの言葉で。
       </p>
-      <%= f.url_field :url,
-                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
     </div>
 
-    <div class="flex flex-col gap-1.5">
-      <%= f.label :summary, class: 'text-[13px] font-medium text-ink' %>
-      <%= f.text_area :summary, rows: 4,
-                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    <%# 白紙の入力欄をいきなり出されると手が止まる。問いの形で取っかかりを置く %>
+    <div class="flex flex-col gap-2.5">
+      <p class="text-[10.5px] tracking-[0.12em] text-ink-subtle">書き出しに困ったら</p>
+      <div class="flex flex-wrap gap-2">
+        <% ['どこで手が止まった？', '誰に読ませたい？', '読み終えて何をした？', 'いつ読むのがいい？'].each do |hint| %>
+          <span class="rounded-[3px] border border-accent-soft bg-accent-soft px-3 py-1.5 text-[12.5px] text-accent">
+            <%= hint %>
+          </span>
+        <% end %>
+      </div>
     </div>
 
-    <div class="flex flex-col gap-1.5">
-      <%= f.label :recommendation, class: 'text-[13px] font-medium text-ink' %>
-      <%# 読み比べるのがこのツールの一番おいしいところなので、ここだけ書き方を促す %>
-      <p class="text-[12px] leading-[1.85] text-ink-subtle">
-        どこが良かったか、誰に読んでほしいか。ここが交換会の楽しみどころです。
-      </p>
-      <%= f.text_area :recommendation, rows: 5,
-                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    <%= f.text_area :recommendation, rows: 6,
+                    placeholder: '3年間ずっと同じ場所で波を数えるだけの話なんですが、後半で……',
+                    data: { counter_target: 'field', action: 'input->counter#count' },
+                    class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3.5 ' \
+                           'text-[14.5px] leading-[2] text-ink' %>
+
+    <%# 上限ではなく目安として出す。字数で切ると、書きたいだけ書けなくなる %>
+    <div class="flex items-center justify-between gap-4">
+      <span class="text-[12px] text-ink-subtle">2〜3行、100字くらいあれば充分に伝わります</span>
+      <span class="tabular text-[12px] text-ink-subtle" data-counter-target="output">
+        <%= book.recommendation.to_s.length %>
+      </span>
     </div>
   </div>
 
-  <div class="flex flex-col gap-1.5 border-t border-line pt-8" data-controller="reveal">
-    <%= f.label :gift_code, class: 'text-[13px] font-medium text-ink' %>
+  <%# 補足の2項目は横に畳んで軽く扱う。狭い画面では縦に積む %>
+  <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+    <div class="flex flex-col gap-2">
+      <div class="flex items-baseline gap-2">
+        <%= f.label :summary, class: 'text-[13px] font-medium text-ink' %>
+        <span class="text-[11px] text-ink-subtle">任意</span>
+      </div>
+      <%= f.text_area :summary, rows: 3, placeholder: 'ストアの紹介文をそのまま貼っても構いません',
+                      class: 'rounded-[5px] border border-line bg-paper px-3.5 py-3 ' \
+                             'text-[13.5px] leading-[1.9] text-ink' %>
+    </div>
 
-    <%# 見えるのは登録した本人と、成立後の受取人だけ（docs/spec.md 8.）。
-        入力欄に貼る時点で不安になる項目なので、誰に見えるのかをその場に書く %>
-    <p class="text-[12px] leading-[1.85] text-ink-subtle">
-      他の参加者には見えません。マッチングが成立したあと、受け取った人にだけ開示されます。
-    </p>
+    <div class="flex flex-col gap-2">
+      <div class="flex items-baseline gap-2">
+        <%= f.label :url, 'ストアのURL', class: 'text-[13px] font-medium text-ink' %>
+        <span class="text-[11px] text-ink-subtle">任意</span>
+      </div>
+      <%= f.url_field :url, placeholder: 'https://',
+                      class: 'rounded-[5px] border border-line bg-paper px-3.5 py-3 text-[13.5px] text-ink' %>
+      <span class="text-[11.5px] leading-[1.7] text-ink-subtle">
+        貼っておくと、受け取った人が同じ版を開けます
+      </span>
+    </div>
+  </div>
 
-    <div class="flex items-stretch gap-2">
+  <%# 機微な項目なので、地から一段沈めた独立した枠に置く %>
+  <div class="flex flex-col gap-3.5 rounded-[5px] border border-line-strong bg-surface-sunken px-6 py-5"
+       data-controller="reveal">
+    <div class="flex items-baseline gap-2">
+      <%= f.label :gift_code, class: 'text-[14px] font-bold text-ink' %>
+      <span class="text-[11px] text-accent">必須</span>
+    </div>
+
+    <div class="flex items-stretch gap-2.5">
       <%# 平文の取得経路は gift_code_for だけ。素のリーダーは private なので、
-          フォームも権限判定を通ってから値を受け取る %>
+          フォームも権限判定を通ってから値を受け取る。
+          伏せ字でも桁が読めるよう等幅で字間を空ける %>
       <%= f.password_field :gift_code, required: true,
                            value: book.gift_code_for(current_user, at: requested_at),
                            autocomplete: 'off',
                            data: { reveal_target: 'field' },
-                           class: 'min-w-0 flex-1 rounded-[5px] border border-line-strong bg-paper px-4 py-3 ' \
-                                  'text-[14.5px] text-ink' %>
+                           class: 'min-w-0 flex-1 rounded-[5px] border border-line-strong bg-paper px-4 py-3.5 ' \
+                                  'font-mono text-[14px] tracking-[0.14em] text-ink' %>
       <%# JavaScript が動かない環境では押しても何も起きないため、送信には関わらせない %>
       <button type="button" data-action="reveal#toggle" data-reveal-target="button"
               class="shrink-0 cursor-pointer rounded-[5px] border border-line-strong bg-paper px-4
@@ -68,12 +113,35 @@
         表示
       </button>
     </div>
+
+    <%# 開いたままの画面を置き去りにさせない。肩越しに覗かれるのは、
+        入力している最中がいちばん起きやすい %>
+    <p class="hidden rounded-[4px] bg-accent-soft px-3.5 py-2.5 text-[12.5px] leading-[1.8] text-accent"
+       data-reveal-target="warning">
+      表示中です。周囲の画面共有にご注意ください。10秒後に自動で伏せ字に戻ります。
+    </p>
+
+    <%# 見えるのは登録した本人と、成立後の受取人だけ（docs/spec.md 8.）。
+        入力欄に貼る時点で不安になる項目なので、誰に見えるのかをその場に置く。
+        主催者に特権が無いことも毎回同じ文で書く %>
+    <p class="border-t border-line pt-3.5 text-[12.5px] leading-[1.9] text-ink">
+      <b class="font-bold">他の参加者には見えません。</b>交換が成立した相手にだけ、結果公開後に開示されます。主催者にも見えません。入力中も既定で伏せ字です。
+    </p>
   </div>
 
-  <div class="flex flex-wrap items-center gap-4 border-t border-line pt-8">
+  <div class="flex flex-wrap items-center gap-3 border-t border-line pt-6">
     <%= f.submit submit_label,
-                 class: 'cursor-pointer rounded-[5px] bg-accent px-6 py-3.5 text-[14.5px] ' \
+                 class: 'cursor-pointer rounded-[5px] bg-accent px-6 py-3 text-[14px] ' \
                         'font-medium text-paper hover:bg-accent-hover' %>
+
+    <%# 何冊でも登録できるので、一覧を経由せずそのまま次を書ける口を主ボタンの隣に置く。
+        編集には次の1冊が無いので出さない %>
+    <% if book.new_record? %>
+      <%= f.submit '登録して、続けてもう1冊', name: 'continue',
+                   class: 'cursor-pointer rounded-[5px] border border-line-strong bg-paper px-6 py-3 ' \
+                          'text-[14px] font-medium text-ink hover:bg-paper-hover' %>
+    <% end %>
+
     <%= link_to 'やめる', exchange_books_path(exchange), class: 'text-[13px]' %>
   </div>
 <% end %>

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,0 +1,79 @@
+<%= form_with model: [exchange, book], class: 'flex flex-col gap-8' do |f| %>
+  <% if book.errors.any? %>
+    <div class="rounded-[5px] border border-accent bg-accent-soft px-5 py-4">
+      <p class="text-[13.5px] font-medium text-accent">入力を確認してください</p>
+      <ul class="mt-2 flex list-disc flex-col gap-1 pl-5 text-[13px] leading-[1.8] text-ink">
+        <% book.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="flex flex-col gap-5">
+    <div class="flex flex-col gap-1.5">
+      <%= f.label :title, class: 'text-[13px] font-medium text-ink' %>
+      <%= f.text_field :title, required: true,
+                       class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <%= f.label :url, class: 'text-[13px] font-medium text-ink' %>
+      <p class="text-[12px] leading-[1.85] text-ink-subtle">
+        ストアの商品ページ。表紙や価格を確かめる先になります。
+      </p>
+      <%= f.url_field :url,
+                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <%= f.label :summary, class: 'text-[13px] font-medium text-ink' %>
+      <%= f.text_area :summary, rows: 4,
+                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <%= f.label :recommendation, class: 'text-[13px] font-medium text-ink' %>
+      <%# 読み比べるのがこのツールの一番おいしいところなので、ここだけ書き方を促す %>
+      <p class="text-[12px] leading-[1.85] text-ink-subtle">
+        どこが良かったか、誰に読んでほしいか。ここが交換会の楽しみどころです。
+      </p>
+      <%= f.text_area :recommendation, rows: 5,
+                      class: 'rounded-[5px] border border-line-strong bg-paper px-4 py-3 text-[14.5px] text-ink' %>
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-1.5 border-t border-line pt-8" data-controller="reveal">
+    <%= f.label :gift_code, class: 'text-[13px] font-medium text-ink' %>
+
+    <%# 見えるのは登録した本人と、成立後の受取人だけ（docs/spec.md 8.）。
+        入力欄に貼る時点で不安になる項目なので、誰に見えるのかをその場に書く %>
+    <p class="text-[12px] leading-[1.85] text-ink-subtle">
+      他の参加者には見えません。マッチングが成立したあと、受け取った人にだけ開示されます。
+    </p>
+
+    <div class="flex items-stretch gap-2">
+      <%# 平文の取得経路は gift_code_for だけ。素のリーダーは private なので、
+          フォームも権限判定を通ってから値を受け取る %>
+      <%= f.password_field :gift_code, required: true,
+                           value: book.gift_code_for(current_user, at: requested_at),
+                           autocomplete: 'off',
+                           data: { reveal_target: 'field' },
+                           class: 'min-w-0 flex-1 rounded-[5px] border border-line-strong bg-paper px-4 py-3 ' \
+                                  'text-[14.5px] text-ink' %>
+      <%# JavaScript が動かない環境では押しても何も起きないため、送信には関わらせない %>
+      <button type="button" data-action="reveal#toggle" data-reveal-target="button"
+              class="shrink-0 cursor-pointer rounded-[5px] border border-line-strong bg-paper px-4
+                     text-[13px] font-medium text-ink hover:bg-paper-hover">
+        表示
+      </button>
+    </div>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-4 border-t border-line pt-8">
+    <%= f.submit submit_label,
+                 class: 'cursor-pointer rounded-[5px] bg-accent px-6 py-3.5 text-[14.5px] ' \
+                        'font-medium text-paper hover:bg-accent-hover' %>
+    <%= link_to 'やめる', exchange_books_path(exchange), class: 'text-[13px]' %>
+  </div>
+<% end %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -4,9 +4,25 @@
   <%# 戻り先は本の一覧だけにする。この画面へ来る入口がそこしかない %>
   <p class="text-[12px]"><%= link_to '本の一覧', exchange_books_path(@exchange) %></p>
 
-  <h1 class="mt-4 text-[26px] font-bold leading-[1.45] text-ink">本を編集する</h1>
+  <h1 class="mt-4 text-[26px] font-bold leading-[1.45] text-ink">「<%= @book.title %>」を編集</h1>
+
+  <p class="mt-3 text-[13px] leading-[1.85] text-ink-muted">
+    登録の締切までは何度でも直せます。
+  </p>
 
   <div class="mt-8">
-    <%= render 'form', exchange: @exchange, book: @book, submit_label: '保存する' %>
+    <%= render 'form', exchange: @exchange, book: @book, submit_label: '変更を保存' %>
+  </div>
+
+  <%# 直しに来て、やはり取り下げると決めることがある。一覧へ戻らせない。
+      保存の導線と面を分け、間違えて押させない %>
+  <div class="mt-10 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 border-t border-line pt-6">
+    <p class="text-[12.5px] leading-[1.8] text-ink-subtle">
+      この本を交換会から取り下げます。
+    </p>
+    <%= button_to 'この本を削除', exchange_book_path(@exchange, @book), method: :delete,
+                  form: { data: { turbo_confirm: book_deletion_confirm(@book, slots: @participation.books.count) } },
+                  class: 'cursor-pointer rounded-[5px] border border-line-strong bg-paper px-5 py-2.5 ' \
+                         'text-[13.5px] font-medium text-ink hover:bg-paper-hover' %>
   </div>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "#{@book.title}を編集" %>
+
+<div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
+  <%# 戻り先は本の一覧だけにする。この画面へ来る入口がそこしかない %>
+  <p class="text-[12px]"><%= link_to '本の一覧', exchange_books_path(@exchange) %></p>
+
+  <h1 class="mt-4 text-[26px] font-bold leading-[1.45] text-ink">本を編集する</h1>
+
+  <div class="mt-8">
+    <%= render 'form', exchange: @exchange, book: @book, submit_label: '保存する' %>
+  </div>
+</div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -4,25 +4,30 @@
     描いている途中で締切をまたいだときに1つの画面の中で出し分けが食い違う %>
 <% registering = @exchange.writable?(:book, at: requested_at) %>
 
+<%# 自分の登録冊数がそのまま取得枠。削除の確認文で使う。
+    読み込み済みの一覧から数えるので、カードごとに COUNT が飛ばない %>
+<% my_books = @books.count { it.participation_id == @participation.id } %>
+
 <div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
   <%# 戻り先は交換会トップだけにする。この画面へ来る入口がそこしかない %>
   <p class="text-[12px]"><%= link_to @exchange.name, exchange_path(@exchange) %></p>
 
-  <%# 狭い画面では見出しと冊数が縦に折り返る %>
-  <div class="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-2">
-    <h1 class="text-[26px] font-bold leading-[1.45] text-ink">本の一覧</h1>
-    <span class="tabular text-[13px] text-ink-muted"><%= @books.size %>冊</span>
-  </div>
-
-  <%# 何冊でも登録できるので、登録を終えて戻ってきたところに次の入口を置く。
-      一覧の下に置くと、冊数が増えるほど次の1冊が遠くなる %>
-  <% if registering %>
-    <div class="mt-6">
-      <%= link_to '本を登録する', new_exchange_book_path(@exchange),
-                  class: 'block rounded-[5px] bg-accent px-5 py-4 text-center text-[14.5px] ' \
-                         'font-medium text-paper no-underline hover:bg-accent-hover' %>
+  <%# 見出しの行の右端に登録の口を置く。何冊でも登録できるので、
+      登録を終えて戻ってきたところがそのまま次の入口になる。
+      一覧の下に置くと、冊数が増えるほど次の1冊が遠くなる。
+      狭い画面では見出しとボタンが縦に折り返る %>
+  <div class="mt-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
+    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-2">
+      <h1 class="text-[26px] font-bold leading-[1.45] text-ink">本の一覧</h1>
+      <span class="tabular text-[13px] text-ink-muted"><%= @books.size %>冊</span>
     </div>
-  <% end %>
+
+    <% if registering %>
+      <%= link_to '本を登録する', new_exchange_book_path(@exchange),
+                  class: 'rounded-[5px] bg-accent px-5 py-2.5 text-[14px] font-medium ' \
+                         'text-paper no-underline hover:bg-accent-hover' %>
+    <% end %>
+  </div>
 
   <% if @books.empty? %>
     <%# 白紙で返すと、壊れているのかまだ誰も登録していないのか区別がつかない %>
@@ -35,12 +40,19 @@
   <% else %>
     <ul class="mt-6 flex flex-col gap-3">
       <% @books.each do |book| %>
-        <li class="rounded-[5px] border border-line bg-paper px-5 py-5">
+        <% mine = book.participation_id == @participation.id %>
+        <li class="rounded-[5px] border bg-paper px-5 py-5 <%= mine ? 'border-line-strong' : 'border-line' %>">
           <%# 誰が登録したかは参加者全員に見える（docs/spec.md 8.）。
               狭い画面ではタイトルと登録者名が縦に折り返る %>
           <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
             <h2 class="text-[17px] font-bold leading-[1.5] text-ink"><%= book.title %></h2>
             <span class="text-[12px] text-ink-subtle"><%= book.registrant.display_name %></span>
+
+            <%# 自分の本は取得枠の数でもある。編集・削除の導線だけで見分けさせると、
+                登録期間を過ぎたとたんにどれが自分の本か分からなくなる %>
+            <% if mine %>
+              <span class="ml-auto rounded-[3px] bg-fill px-2 py-0.5 text-[11px] text-ink-muted">自分の本</span>
+            <% end %>
           </div>
 
           <%# あらすじは冒頭だけ。数行を丸ごと並べると、一覧をざっと眺められなくなる %>
@@ -64,14 +76,14 @@
 
           <%# 自分の本にだけ出す。押しても通らない導線を残さないよう、
               登録期間の外では出さない %>
-          <% if registering && book.participation_id == @participation.id %>
+          <% if registering && mine %>
             <div class="mt-4 flex items-center gap-4 border-t border-line pt-4">
               <%= link_to '編集', edit_exchange_book_path(@exchange, book), class: 'text-[13px]' %>
 
-              <%# 消すと、その本への他の人の希望も一緒に消える。取り返しがつかないので確認を挟む %>
+              <%# 取り返しがつかないので確認を挟む。文言は削除の口が2か所あるため helper に置く %>
               <%= button_to '削除', exchange_book_path(@exchange, book), method: :delete,
-                            form: { data: { turbo_confirm: "「#{book.title}」の登録を取り消します。よろしいですか？" } },
-                            class: 'cursor-pointer text-[13px] text-ink-muted underline hover:text-accent' %>
+                            form: { data: { turbo_confirm: book_deletion_confirm(book, slots: my_books) } },
+                            class: 'cursor-pointer text-[13px] text-ink-subtle underline hover:text-accent' %>
             </div>
           <% end %>
         </li>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "#{@exchange.name}の本" %>
 
+<%# 登録・編集・削除の可否は1回だけ引く。カードごとに引き直すと、
+    描いている途中で締切をまたいだときに1つの画面の中で出し分けが食い違う %>
+<% registering = @exchange.writable?(:book, at: requested_at) %>
+
 <div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
   <%# 戻り先は交換会トップだけにする。この画面へ来る入口がそこしかない %>
   <p class="text-[12px]"><%= link_to @exchange.name, exchange_path(@exchange) %></p>
@@ -10,9 +14,18 @@
     <span class="tabular text-[13px] text-ink-muted"><%= @books.size %>冊</span>
   </div>
 
+  <%# 何冊でも登録できるので、登録を終えて戻ってきたところに次の入口を置く。
+      一覧の下に置くと、冊数が増えるほど次の1冊が遠くなる %>
+  <% if registering %>
+    <div class="mt-6">
+      <%= link_to '本を登録する', new_exchange_book_path(@exchange),
+                  class: 'block rounded-[5px] bg-accent px-5 py-4 text-center text-[14.5px] ' \
+                         'font-medium text-paper no-underline hover:bg-accent-hover' %>
+    </div>
+  <% end %>
+
   <% if @books.empty? %>
-    <%# 白紙で返すと、壊れているのかまだ誰も登録していないのか区別がつかない。
-        登録の導線は #21 で足すので、ここでは待てば埋まることだけを伝える %>
+    <%# 白紙で返すと、壊れているのかまだ誰も登録していないのか区別がつかない %>
     <div class="mt-6 rounded-[5px] border border-line bg-paper px-5 py-6">
       <p class="text-[14.5px] font-medium text-ink">まだ本は登録されていません。</p>
       <p class="mt-2 text-[13px] leading-[1.85] text-ink-muted">
@@ -46,6 +59,19 @@
               <%# 改行を活かすので、タグの内側で折り返さない。
                   pre-line はタグ直後の改行も1行として残す %>
               <p class="mt-1.5 whitespace-pre-line text-[14px] leading-[1.95] text-ink"><%= book.recommendation %></p>
+            </div>
+          <% end %>
+
+          <%# 自分の本にだけ出す。押しても通らない導線を残さないよう、
+              登録期間の外では出さない %>
+          <% if registering && book.participation_id == @participation.id %>
+            <div class="mt-4 flex items-center gap-4 border-t border-line pt-4">
+              <%= link_to '編集', edit_exchange_book_path(@exchange, book), class: 'text-[13px]' %>
+
+              <%# 消すと、その本への他の人の希望も一緒に消える。取り返しがつかないので確認を挟む %>
+              <%= button_to '削除', exchange_book_path(@exchange, book), method: :delete,
+                            form: { data: { turbo_confirm: "「#{book.title}」の登録を取り消します。よろしいですか？" } },
+                            class: 'cursor-pointer text-[13px] text-ink-muted underline hover:text-accent' %>
             </div>
           <% end %>
         </li>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "本を登録 — #{@exchange.name}" %>
+
+<div class="mx-auto w-full max-w-[640px] px-4 py-10 sm:px-6">
+  <%# 戻り先は本の一覧だけにする。この画面へ来る入口がそこしかない %>
+  <p class="text-[12px]"><%= link_to '本の一覧', exchange_books_path(@exchange) %></p>
+
+  <h1 class="mt-4 text-[26px] font-bold leading-[1.45] text-ink">本を登録する</h1>
+
+  <%# 登録した冊数がそのまま取得枠になる。何冊でも登録できることを最初に伝える %>
+  <p class="mt-3 text-[13px] leading-[1.85] text-ink-muted">
+    登録した冊数だけ本を受け取れます。何冊でも登録できます。
+  </p>
+
+  <div class="mt-8">
+    <%= render 'form', exchange: @exchange, book: @book, submit_label: '登録する' %>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,6 +27,7 @@ ja:
       created: 交換会を作成しました
       updated: 交換会を更新しました
   book:
+    deletion_confirm: 「%{title}」の登録を取り消します。取得枠が%{before}冊から%{after}冊に減り、ギフトコードも消えます。よろしいですか？
     flash:
       # 登録した冊数がそのまま取得枠になるので、増えたことをその場で伝える
       created: 「%{title}」を登録しました。あなたの取得枠は%{count}冊になりました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,11 @@ ja:
     flash:
       created: 交換会を作成しました
       updated: 交換会を更新しました
+  book:
+    flash:
+      created: 本を登録しました
+      updated: 本の内容を更新しました
+      destroyed: 本の登録を取り消しました
   participation:
     flash:
       joined: 交換会に参加しました
@@ -33,6 +38,12 @@ ja:
     login_required: "%{name}に参加するには、Google でのログインが必要です"
   activerecord:
     attributes:
+      book:
+        title: タイトル
+        summary: あらすじ
+        url: URL
+        recommendation: おすすめポイント
+        gift_code: ギフトコード
       exchange:
         name: 交換会名
         description: 概要

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,7 +28,8 @@ ja:
       updated: 交換会を更新しました
   book:
     flash:
-      created: 本を登録しました
+      # 登録した冊数がそのまま取得枠になるので、増えたことをその場で伝える
+      created: 「%{title}」を登録しました。あなたの取得枠は%{count}冊になりました
       updated: 本の内容を更新しました
       destroyed: 本の登録を取り消しました
   participation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
   # 本は必ずどれか1つの交換会に属し、単独では意味を持たない。
   # 交換会の下に置くと、参加しているかどうかの判定を親から引ける
   resources :exchanges, only: [:index, :show, :new, :create, :edit, :update] do
-    resources :books, only: [:index]
+    # 詳細（#23）だけがまだ無い。それ以外は揃っている
+    resources :books, except: [:show]
   end
 
   # 招待URL。交換会の id ではなく招待トークンで引く。

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -32,9 +32,27 @@ RSpec.describe Book do
     expect(book).to be_persisted
   end
 
-  it 'タイトルとギフトコードは欠かせない' do
-    expect { create(:book, title: nil) }.to raise_error(ActiveRecord::NotNullViolation)
-    expect { create(:book, gift_code: nil) }.to raise_error(ActiveRecord::NotNullViolation)
+  # DB の例外ではなくフォームのエラーとして返す。
+  # NOT NULL に任せると、入力欄に戻さず 500 になる
+  it 'タイトルが空だと保存できない' do
+    book = build(:book, title: '  ')
+
+    expect(book).not_to be_valid
+    expect(book.errors).to be_of_kind(:title, :blank)
+  end
+
+  it 'ギフトコードが空だと保存できない' do
+    book = build(:book, gift_code: '  ')
+
+    expect(book).not_to be_valid
+    expect(book.errors).to be_of_kind(:gift_code, :blank)
+  end
+
+  it 'バリデーションを外しても DB が空を拒む' do
+    expect { build(:book, title: nil).save(validate: false) }
+      .to raise_error(ActiveRecord::NotNullViolation)
+    expect { build(:book, gift_code: nil).save(validate: false) }
+      .to raise_error(ActiveRecord::NotNullViolation)
   end
 
   it '登録者のいない本は保存できない' do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -33,19 +33,21 @@ RSpec.describe Book do
   end
 
   # DB の例外ではなくフォームのエラーとして返す。
-  # NOT NULL に任せると、入力欄に戻さず 500 になる
+  # NOT NULL に任せると、入力欄に戻さず 500 になる。
+  # 型ではなく画面に出る文言で固定する。型で照合すると、属性名の訳を
+  # ja.yml から落としても spec が通り、「Titleを入力してください」が出続ける
   it 'タイトルが空だと保存できない' do
     book = build(:book, title: '  ')
 
     expect(book).not_to be_valid
-    expect(book.errors).to be_of_kind(:title, :blank)
+    expect(book.errors.full_messages).to include('タイトルを入力してください')
   end
 
   it 'ギフトコードが空だと保存できない' do
     book = build(:book, gift_code: '  ')
 
     expect(book).not_to be_valid
-    expect(book.errors).to be_of_kind(:gift_code, :blank)
+    expect(book.errors.full_messages).to include('ギフトコードを入力してください')
   end
 
   it 'バリデーションを外しても DB が空を拒む' do

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -265,6 +265,43 @@ RSpec.describe BooksController do
 
       expect(response.body).to include('他の参加者には見えません')
     end
+
+    # 主催者に特権はない（docs/spec.md 8.）。ここを書かないと、
+    # 主催者には見えるのだろうと思ったまま入力することになる
+    it '主催者にも見えないことが書かれている' do
+      open_form
+
+      expect(response.body).to include('主催者にも見えません')
+    end
+
+    # 必須は2項目だけ。印が無いと、任意の欄まで埋めないと進めないように見える
+    it '必須の項目に印が付く' do
+      open_form
+
+      expect(response.body.scan('必須').size).to eq(2)
+    end
+
+    it '任意の項目にも印が付く' do
+      open_form
+
+      expect(response.body).to include('任意')
+    end
+
+    # 仕様の順ではなく書く気になる順に並べる。おすすめポイントが主役で、
+    # 任意のあらすじは書けなくても先に進める位置に置く
+    it 'タイトル・おすすめポイント・あらすじ・ギフトコードの順に並ぶ' do
+      open_form
+
+      order = ['タイトル', 'おすすめポイント', 'あらすじ', 'ギフトコード'].map { response.body.index(it) }
+      expect(order).to eq(order.compact.sort)
+    end
+
+    # みんながいちばん読むところなので、書き出しの取っかかりを添える
+    it 'おすすめポイントに書き出しの手がかりが出る' do
+      open_form
+
+      expect(response.body).to include('どこで手が止まった？')
+    end
   end
 
   describe '#create' do
@@ -293,11 +330,27 @@ RSpec.describe BooksController do
       expect(book.recommendation).to eq('読み終わったあとに空が違って見える。')
     end
 
-    # 続けてもう1冊登録できるよう、着地先は一覧に揃える
     it '登録すると本の一覧へ戻る' do
       register
 
       expect(response).to redirect_to(exchange_books_path(exchange))
+    end
+
+    # 何冊でも登録できる。一覧を経由させると、1冊ごとに2画面を往復することになる
+    it '続けて登録するときは登録フォームへ戻る' do
+      post exchange_books_path(exchange),
+           params: { book: { title: '銀河の果ての本屋', gift_code: 'GIFT-1234' },
+                     continue: '登録して、続けてもう1冊' }
+
+      expect(response).to redirect_to(new_exchange_book_path(exchange))
+    end
+
+    # 登録した冊数がそのまま取得枠になる。増えたことをその場で伝える
+    it '登録したタイトルと取得枠を知らせる' do
+      register
+
+      expect(flash[:notice]).to include('銀河の果ての本屋')
+      expect(flash[:notice]).to include('1冊')
     end
 
     it 'タイトルが空だと保存されない' do

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -154,5 +154,315 @@ RSpec.describe BooksController do
 
       expect(response).to have_http_status(:ok)
     end
+
+  end
+
+  # フェーズは日時から導出されるため、登録期間の外は日程をずらして作る。
+  # 交換会の factory の既定は登録期間中
+  def outside_registration
+    exchange.update!(registration_starts_at: 3.weeks.from_now,
+                     registration_ends_at: 4.weeks.from_now,
+                     wish_ends_at: 5.weeks.from_now)
+  end
+
+  describe '#new' do
+    def open_form
+      get new_exchange_book_path(exchange)
+    end
+
+    it '登録期間中は開ける' do
+      open_form
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # 押しても通らないフォームを開かせない（docs/spec.md 6.4）
+    it '登録期間外は開けない' do
+      outside_registration
+
+      open_form
+
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '参加していなければ見つからない' do
+      log_in_as(create(:user))
+
+      open_form
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'ログインしていなければログイン画面へ送る' do
+      log_out
+
+      open_form
+
+      expect(response).to redirect_to(login_path)
+    end
+
+    # 伏せ字にしておかないと、肩越しに覗かれるだけでギフトコードが渡る
+    it 'ギフトコードの入力欄が伏せ字になっている' do
+      open_form
+
+      expect(response.body).to include('type="password"')
+    end
+
+    it '他人には見えないことが書かれている' do
+      open_form
+
+      expect(response.body).to include('他の参加者には見えません')
+    end
+  end
+
+  describe '#create' do
+    def register(**attributes)
+      post exchange_books_path(exchange),
+           params: { book: { title: '銀河の果ての本屋', gift_code: 'GIFT-1234' }.merge(attributes) }
+    end
+
+    it '本を登録できる' do
+      expect { register }.to change { participation.books.count }.by(1)
+    end
+
+    it '登録した本人の本になる' do
+      register
+
+      expect(Book.last.participation).to eq(participation)
+    end
+
+    it 'あらすじ・URL・おすすめポイントも保存される' do
+      register(summary: 'ある町の書店の話。', url: 'https://example.com/book',
+               recommendation: '読み終わったあとに空が違って見える。')
+
+      book = Book.last
+      expect(book.summary).to eq('ある町の書店の話。')
+      expect(book.url).to eq('https://example.com/book')
+      expect(book.recommendation).to eq('読み終わったあとに空が違って見える。')
+    end
+
+    # 続けてもう1冊登録できるよう、着地先は一覧に揃える
+    it '登録すると本の一覧へ戻る' do
+      register
+
+      expect(response).to redirect_to(exchange_books_path(exchange))
+    end
+
+    it 'タイトルが空だと保存されない' do
+      expect { register(title: '') }.not_to(change { participation.books.count })
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'ギフトコードが空だと保存されない' do
+      expect { register(gift_code: '') }.not_to(change { participation.books.count })
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    # クライアントの時計ではなくサーバー側で判定する（docs/spec.md 4. フェーズ）
+    it '登録期間外は登録できない' do
+      outside_registration
+
+      expect { register }.not_to(change { participation.books.count })
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '結果公開後は登録できない' do
+      exchange.update!(matched_at: 1.day.ago)
+
+      expect { register }.not_to(change { participation.books.count })
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '参加していなければ登録できない' do
+      log_in_as(create(:user))
+
+      expect { register }.not_to(change(Book, :count))
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'ログインしていなければ登録できない' do
+      log_out
+
+      expect { register }.not_to(change(Book, :count))
+    end
+  end
+
+  # 他人の本。編集も削除も、自分の本にしか届かないことを確かめる入れ物
+  def others_book(**attributes)
+    create(:book, participation: create(:participation, exchange:), **attributes)
+  end
+
+  describe '#edit' do
+    let!(:book) { create(:book, participation:, gift_code: 'GIFT-1234') }
+
+    def open_form(target = book)
+      get edit_exchange_book_path(exchange, target)
+    end
+
+    it '登録期間中は開ける' do
+      open_form
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '登録期間外は開けない' do
+      outside_registration
+
+      open_form
+
+      expect(response).to have_http_status(:conflict)
+    end
+
+    # 探し直させるのは手間でしかない。登録した本人には常時見えてよい値
+    it 'ギフトコードが入力欄に入っている' do
+      open_form
+
+      expect(response.body).to include('GIFT-1234')
+    end
+
+    # 403 だと、その id の本が実在することを URL を試すだけで確かめられる
+    it '他人の本は見つからない' do
+      open_form(others_book)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it '参加していなければ見つからない' do
+      log_in_as(create(:user))
+
+      open_form
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'ログインしていなければログイン画面へ送る' do
+      log_out
+
+      open_form
+
+      expect(response).to redirect_to(login_path)
+    end
+  end
+
+  describe '#update' do
+    let!(:book) { create(:book, participation:, title: '前のタイトル') }
+
+    def rename(target = book, **attributes)
+      patch exchange_book_path(exchange, target),
+            params: { book: { title: '新しいタイトル' }.merge(attributes) }
+    end
+
+    it '自分の本を編集できる' do
+      rename
+
+      expect(book.reload.title).to eq('新しいタイトル')
+    end
+
+    it '編集すると本の一覧へ戻る' do
+      rename
+
+      expect(response).to redirect_to(exchange_books_path(exchange))
+    end
+
+    it 'タイトルが空だと保存されない' do
+      rename(title: '')
+
+      expect(book.reload.title).to eq('前のタイトル')
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'ギフトコードを変更できる' do
+      rename(gift_code: 'GIFT-5678')
+
+      expect(book.reload.gift_code_for(user, at: Time.current)).to eq('GIFT-5678')
+    end
+
+    it '登録期間外は編集できない' do
+      outside_registration
+
+      rename
+
+      expect(book.reload.title).to eq('前のタイトル')
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '結果公開後は編集できない' do
+      exchange.update!(matched_at: 1.day.ago)
+
+      rename
+
+      expect(book.reload.title).to eq('前のタイトル')
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '他人の本は編集できない' do
+      target = others_book(title: '他の人の本')
+
+      rename(target)
+
+      expect(target.reload.title).to eq('他の人の本')
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'ログインしていなければ編集できない' do
+      log_out
+
+      rename
+
+      expect(book.reload.title).to eq('前のタイトル')
+    end
+  end
+
+  describe '#destroy' do
+    let!(:book) { create(:book, participation:) }
+
+    def remove(target = book)
+      delete exchange_book_path(exchange, target)
+    end
+
+    it '自分の本を削除できる' do
+      expect { remove }.to change { participation.books.count }.by(-1)
+    end
+
+    it '削除すると本の一覧へ戻る' do
+      remove
+
+      expect(response).to redirect_to(exchange_books_path(exchange))
+    end
+
+    it '他人の本は削除できない' do
+      target = others_book
+
+      expect { remove(target) }.not_to(change(Book, :count))
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # 希望提出期間に入ってから消えると、取得枠の計算が壊れる
+    it '登録期間外は削除できない' do
+      outside_registration
+
+      expect { remove }.not_to(change(Book, :count))
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '結果公開後は削除できない' do
+      exchange.update!(matched_at: 1.day.ago)
+
+      expect { remove }.not_to(change(Book, :count))
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it '参加していなければ削除できない' do
+      log_in_as(create(:user))
+
+      expect { remove }.not_to(change(Book, :count))
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'ログインしていなければ削除できない' do
+      log_out
+
+      expect { remove }.not_to(change(Book, :count))
+    end
   end
 end

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -155,6 +155,58 @@ RSpec.describe BooksController do
       expect(response).to have_http_status(:ok)
     end
 
+    # 登録・編集・削除のすべてに、この画面から入れるようにする。
+    # リンクは行き先ができてから足す（#22 の時点では行き先が無かった）
+    describe '登録・編集・削除の導線' do
+      it '登録期間中は登録ボタンが出る' do
+        open_list
+
+        expect(response.body).to include(new_exchange_book_path(exchange))
+      end
+
+      it '1冊も登録されていなくても登録ボタンが出る' do
+        open_list
+
+        expect(response.body).to include('まだ本は登録されていません')
+        expect(response.body).to include(new_exchange_book_path(exchange))
+      end
+
+      it '登録期間外は登録ボタンが出ない' do
+        outside_registration
+
+        open_list
+
+        expect(response.body).not_to include(new_exchange_book_path(exchange))
+      end
+
+      it '自分の本には編集と削除が出る' do
+        mine = create(:book, participation:)
+
+        open_list
+
+        expect(response.body).to include(edit_exchange_book_path(exchange, mine))
+        expect(response.body).to include('登録を取り消します')
+      end
+
+      it '他人の本には編集も削除も出ない' do
+        theirs = create(:book, participation: create(:participation, exchange:))
+
+        open_list
+
+        expect(response.body).not_to include(edit_exchange_book_path(exchange, theirs))
+      end
+
+      # 押しても通らない導線を残さない
+      it '登録期間外は自分の本にも編集と削除が出ない' do
+        mine = create(:book, participation:)
+        outside_registration
+
+        open_list
+
+        expect(response.body).not_to include(edit_exchange_book_path(exchange, mine))
+        expect(response.body).not_to include('登録を取り消します')
+      end
+    end
   end
 
   # フェーズは日時から導出されるため、登録期間の外は日程をずらして作る。

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -188,6 +188,34 @@ RSpec.describe BooksController do
         expect(response.body).to include('登録を取り消します')
       end
 
+      # 消えるのは本だけではない。取得枠が1つ減り、その本への他の人の希望も消える
+      it '削除の確認で取得枠が減ることを伝える' do
+        create_list(:book, 2, participation:)
+
+        open_list
+
+        expect(response.body).to include('取得枠が2冊から1冊に減り')
+      end
+
+      # 自分の本は取得枠の数でもある。導線の有無だけで見分けさせると、
+      # 登録期間を過ぎたとたんにどれが自分の本か分からなくなる
+      it '自分の本には印が付く' do
+        create(:book, participation:, title: '灯台守の一年')
+        outside_registration
+
+        open_list
+
+        expect(response.body).to include('自分の本')
+      end
+
+      it '他人の本には印が付かない' do
+        create(:book, participation: create(:participation, exchange:), title: '十三番目の便り')
+
+        open_list
+
+        expect(response.body).not_to include('自分の本')
+      end
+
       it '他人の本には編集も削除も出ない' do
         theirs = create(:book, participation: create(:participation, exchange:))
 
@@ -430,6 +458,13 @@ RSpec.describe BooksController do
       open_form(others_book)
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    # 直しに来て、やはり取り下げると決めることがある。一覧へ戻らせない
+    it '編集画面からも削除できる' do
+      open_form
+
+      expect(response.body).to include('登録を取り消します')
     end
 
     it '参加していなければ見つからない' do

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -381,14 +381,18 @@ RSpec.describe BooksController do
       expect(flash[:notice]).to include('1冊')
     end
 
-    it 'タイトルが空だと保存されない' do
+    # 何が足りないのかを入力欄まで返す。422 で止めるだけでは、
+    # 保存されなかったことしか分からない
+    it 'タイトルが空だと保存されず、理由が画面に出る' do
       expect { register(title: '') }.not_to(change { participation.books.count })
       expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('タイトルを入力してください')
     end
 
-    it 'ギフトコードが空だと保存されない' do
+    it 'ギフトコードが空だと保存されず、理由が画面に出る' do
       expect { register(gift_code: '') }.not_to(change { participation.books.count })
       expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('ギフトコードを入力してください')
     end
 
     # クライアントの時計ではなくサーバー側で判定する（docs/spec.md 4. フェーズ）


### PR DESCRIPTION
本の登録・編集・削除フォームを作り、本の一覧からそのすべてに入れるようにしました。

closes #21

## 変えたこと

- `Book` にタイトルとギフトコードの presence バリデーションを足した。これまでは DB の NOT NULL だけで、空のまま送ると 500 になっていた
- `BooksController` に `new` / `create` / `edit` / `update` / `destroy` を足した
- 本の一覧に「本を登録する」ボタンと、自分の本にだけ出る編集・削除の導線を足した
- Stimulus コントローラを2つ置いた（`reveal` — 伏せ字の開閉、`counter` — おすすめポイントの文字数）

## 判断したこと

**フェーズの検証は `guard_phase :book, except: [:index]`。** `only:` ではなく `except:` にして、既定を「止める」に倒しました。書き込みのアクションが増えたときに、書き忘れが素通りになりません。詳細（#23）を足すときは、読み取りなので `except:` に並べる必要があります。コメントにも残しました。

**登録期間外は `new` と `edit` も止めます。** 押しても通らないフォームを開かせても仕方がないため（`docs/spec.md` 6.4「登録期間中のみ開ける」）。

**他人の本は 404。** 403 を返すと、その id の本が実在することを URL を試すだけで確かめられます。

**ギフトコードの入力欄は、編集時も既存の値で埋めます。** 空欄にすると、タイトルを直すだけでもコードを探し直すことになるためです。登録した本人には常時見える値（`docs/spec.md` 8.）なので可視性ルールには触れません。値はフォームでも `gift_code_for` を通し、取得経路を増やしていません。

## デザイン資料との突き合わせ

**当初 Claude Design の「本の登録フォームと詳細」を見ずに組んでいたため、後半の2コミットで差を埋めました。** 埋めたのは次です。

- 項目を「書く気になる順」に並べ替えた（タイトル → おすすめポイント → あらすじと URL → ギフトコード）
- おすすめポイントに専用の面を与えた。朱の左罫、大きなラベル、書き出しの問い、2倍の高さ、文字数の目安
- あらすじと URL を2列に畳んだ
- タイトルとギフトコードに「必須」、あらすじと URL に「任意」の印を付けた
- ギフトコードの注記に「主催者にも見えません」を足した
- ギフトコードは表示から10秒で自動的に伏せ字へ戻る。表示中は警告を出す
- ギフトコードの入力欄を等幅＋字間にした
- 「登録して、続けてもう1冊」を主ボタンの隣に置いた
- 一覧で自分の本に印を付け、登録ボタンを見出しの行へ移した
- 削除の確認に、取得枠が減ることとギフトコードも消えることを書いた。編集フォームにも削除の口を置いた

**採らなかったもの。**

- **「差し替え」ボタン** — 編集フォームは既存のギフトコードを埋めているので、差し替えは入力欄を書き換えるだけで済みます
- **ヘッダーの「登録期間 残り 6日 3時間」** — 共通ヘッダーは #81 の担当です
- **下書きの自動保存** — `docs/spec.md` 6.4 にも #21 の完了条件にもありません。保存先の設計が要るので、必要なら別 issue にすべきだと思います
- **一覧のカードのグリッド・展開** — #22 で1カラムに決めた形をこの PR で作り直すのは範囲外と判断しました

## 完了条件

すべて満たしています。

- [x] 登録期間中に本を登録・編集・削除でき、それ以外のフェーズではサーバー側で拒否される
- [x] タイトルとギフトコードが空だと保存できない
- [x] ギフトコードの入力欄が伏せ字で、「表示」ボタンで開ける
- [x] 他人には見えないことがフォーム上に明記されている
- [x] 自分以外の本を編集・削除できない
- [x] 登録直後に続けてもう1冊登録できる導線がある
- [x] 本の一覧から登録・編集・削除のすべてに入れる
- [x] 登録・編集・削除のあとの着地先が本の一覧である（「登録して、続けてもう1冊」だけフォームへ戻ります）

## 確認していないこと

**JavaScript を実際に動かした確認はできていません。** このリポジトリには system spec の土台が無く、Playwright もブラウザのバイナリがこの環境に入りませんでした。Node の依存をこの issue で持ち込むのは筋が違うと判断しています。

代わりに、dev サーバーへ HTTP で当てて次まで確認しました。

- `data-controller="reveal"` / `data-controller="counter"` と各 target・action が出ていること
- ギフトコードの入力欄が `type="password"` で、編集時は既存の値が入っていること
- `reveal_controller.js` と `counter_controller.js` が 200 で配信されること
- 一覧に「自分の本」の印と、取得枠を含む削除の確認文が出ること

残るのは、クリックしたときのトグル・自動復帰・文字数の更新です。

## 検証

- `bin/rspec` — 434 examples, 0 failures
- `bin/rubocop` — 78 files, no offenses
- `bin/ci` — 全項目通過
- 5つのコミットそれぞれ単体で `bin/rspec` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
