### PR TITLE
NOT NULL のカラムを検証でも弾く

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3,4 +3,9 @@
 class Assignment < ApplicationRecord
   belongs_to :book
   belongs_to :participation
+
+  # NOT NULL のカラムは検証でも弾く。DB の例外ではなく検証の失敗として返すため。
+  # 返却フラグは false が正しい値なので presence では見られない。
+  # 巡は余り物の割当で nil になるため、ここには並べない
+  validates :returned, inclusion: { in: [true, false] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,11 @@ class User < ApplicationRecord
   # 主催した交換会もここから引ける。主催であることは条件にしない
   has_many :exchanges, through: :participations
 
+  # NOT NULL のカラムは presence でも弾く。DB の例外ではなく検証の失敗として返すため。
+  # プロバイダと uid は OmniAuth から、表示名は初回だけプロバイダの名前を借りて入る。
+  # 名前を返さないプロバイダを足したときに、ログインの経路で 500 になるのを防ぐ
+  validates :provider, :uid, :display_name, presence: true
+
   # OAuth のコールバックで受け取った認証情報から利用者を引く。
   # 表示名は本人が変えられるため、初回の初期値としてだけプロバイダの名前を借りる。
   # アバターはプロバイダが返す URL をそのまま持つので、ログインのたびに追従する

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Assignment do
     expect(described_class.new.returned).to be(false)
   end
 
+  # false を欠落と区別する必要があるため、presence では見られない
+  it '返却フラグが無ければ保存できない' do
+    expect(build(:assignment, returned: nil)).not_to be_valid
+    expect(build(:assignment, returned: false)).to be_valid
+  end
+
   it '本と受取人のどちらが欠けても保存できない' do
     expect { build(:assignment, book: nil).save(validate: false) }
       .to raise_error(ActiveRecord::NotNullViolation)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,9 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  it '必須のカラムに nil を保存できない' do
+  it '必須のカラムが無ければ保存できない' do
     [:provider, :uid, :display_name].each do |column|
-      expect { create(:user, column => nil) }
+      expect(build(:user, column => nil)).not_to be_valid, "#{column} が検証されていない"
+    end
+  end
+
+  # バリデーションを迂回しても DB が弾く
+  it '必須のカラムに nil を書き込めない' do
+    [:provider, :uid, :display_name].each do |column|
+      expect { build(:user, column => nil).save(validate: false) }
         .to raise_error(ActiveRecord::NotNullViolation), "#{column} が NOT NULL になっていない"
     end
   end


### PR DESCRIPTION
closes #101

NOT NULL のカラムのうち、モデルに検証が無かったものへ検証を足した。DB の例外がそのまま上がると、フォームのエラーではなく 500 になる。

## 変えたもの

| モデル | 列 | 検証 |
|---|---|---|
| `User` | `provider` `uid` `display_name` | `presence: true` |
| `Assignment` | `returned` | `inclusion: { in: [true, false] }` |

全テーブルの NOT NULL を洗った結果、抜けていたのはこの4つだけだった。`books`（`title` `gift_code`）と `exchanges`（7列）には既に付いており、`participations` と `wishes` の残りは `belongs_to` の既定で必須になる。

## 決めたこと

**`returned` に `presence: true` は使えない。** `false` が正しい値なので、`presence` だと欠落と区別できない。`inclusion` で見て、`false` が valid のままであることも spec に置いた。

**`created_at` と `updated_at` には付けない。** Rails が値を入れるのは検証を通ったあとなので、付けると全レコードの作成が落ちる。`assignments.round` は余り物の割当で nil になるため対象外。

**`User` の3列を弾くのは、ログインの経路を守るため。** 表示名は初回だけプロバイダの名前を借りて入るので、名前を返さないプロバイダを足すと `from_omniauth` の `save!` が `NotNullViolation` を上げる。

## 経緯

#24 で `wishes.position` に検証を足したときに、他のモデルにも同じ穴があると分かった。一度 #100 に同梱したが、範囲が違うためこちらへ移した。#100 側は push 済みのため、履歴を書き換えず revert を積んである。

## 検証

`bin/rspec`（496 examples, 0 failures）、`bin/rubocop`、`bin/ci` を通した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)