### PR TITLE
編集の自動承認をリポジトリから外す

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,5 @@
 {
   "permissions": {
-    "defaultMode": "acceptEdits",
-
     "allow": [
       "Bash(bin/rails:*)",
       "Bash(bin/rake:*)",


### PR DESCRIPTION
`.claude/settings.json` の `permissions.defaultMode: "acceptEdits"` を削除する。

## 背景

この設定は `settings.json` の新規作成コミット d95400e に最初から入っていたが、
コミットメッセージは devcontainer のマウント追加と「基本的な操作を許可」に触れるのみで、
`defaultMode` には言及がない。`CLAUDE.md`、`docs/spec.md`、その他のファイルにも記録はなく、
後続コミットでもこの行は一度も触られていない。「devcontainer で隔離されているから」という
推測は立つが、根拠は残っていない。

## 外す理由

`settings.json` は git 管理なので clone した全員に効く。編集を確認なしで通すかどうかは
環境に依存する個人の判断であり、devcontainer の外で作業する人にまで固定したくない。

## 影響

`defaultMode` は allow / ask / deny のどれにもマッチしなかったときの既定動作なので、
Bash の許可リストは影響を受けない。変わるのは Edit / Write のたびに確認が出るようになる点だけ。

手元で従来どおり自動承認したい場合は、gitignore 済みの `.claude/settings.local.json` に置くか、
起動時に `--permission-mode acceptEdits` を渡せば足りる。

## 検証

Claude Code の設定ファイルのみの変更で、アプリケーションコードには触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)