### PR TITLE
json を 2.21.2 に上げる

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     kamal (2.12.0)
@@ -518,7 +518,7 @@ CHECKSUMS
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kamal (2.12.0) sha256=c51d1ab085e515470f98d0c0f043637122b5ebf76e8b610cb1fbbed0b7f9b8fa
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0


### PR DESCRIPTION
`bin/bundler-audit` が落ちるようになったので、`json` を上げます。

## 何が起きているか

`json` 2.21.1 に CVE-2026-71847（GHSA-9hj4-r449-hfvc）が公表されました。
`JSON::ResumableParser#partial_value` が解放済みのバッファを参照して落ちるというもので、修正は 2.21.2 です。

ruby-advisory-db への収載は 2026-08-09 で、手元の db が古いあいだは `bin/ci` がローカルで通ってしまいます。落ちるのは GitHub Actions の `scan_ruby` だけです。

## 変更

`json` は直接の依存ではなく、`activesupport` / `faraday` / `rubocop` から引かれています。
`Gemfile` には足さず、`bundle update json` で lock だけを上げました。

## 確認

`bin/rspec`（791 examples, 0 failures）と `bin/ci` を通しました。
`bin/bundler-audit` は `No vulnerabilities found` になっています。

このツールに `JSON::ResumableParser` を使っている箇所はありません。踏んでいた不具合の修正ではなく、監査を通すための追従です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)