### PR TITLE
brakeman を 8.0.6 へ上げる

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -491,7 +491,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1


### PR DESCRIPTION
`bin/ci` の brakeman が、警告が1件も無いのに exit 5 で落ちていた。出ていたのは次の1行だけ。

```
Brakeman 8.0.5 is not the latest version 8.0.6
```

brakeman は新しい版が出ていると exit 5 を返し、`bin/ci` は `--exit-on-error` を付けて呼ぶため、そのまま失敗になる。差分の内容とは無関係なので、どのブランチで作業していても `bin/ci` が緑にならない。

issue には紐づかない雑務なので、番号なしのブランチで切り出した。

## 確かめたこと

- `bin/ci` — brakeman を含めて全部通る（`Errors: 0 / Security Warnings: 0 / No warnings found`）
- `bin/rspec` — 921 examples, 0 failures
- 8.0.6 で警告が増えていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)