### PR TITLE
Solid Queue をセットアップする

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server
+web: SOLID_QUEUE_IN_PUMA=true bin/rails server
 css: bin/rails tailwindcss:watch

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ bin/dev
 `bin/dev` は Rails サーバーと Tailwind の watch を同時に動かす（`Procfile.dev`）。
 http://localhost:3000 で開く。
 
+ジョブは `SOLID_QUEUE_IN_PUMA=true` で Puma の中の Solid Queue が実行する。
+`bin/rails server` を直に叩くとワーカーが立たず、積んだジョブは待ったままになる。
+積んだジョブが走るところは、たとえば次で確かめられる。
+
+```
+bin/rails runner 'SolidQueue::RecurringJob.perform_later("Rails.logger.info(%q(job ran))")'
+```
+
 OAuth のクライアント ID と秘密鍵は credentials に置く。未設定でもログイン画面までは開ける。
 
 ```

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,42 +21,59 @@ default: &default
 
 
 development:
-  <<: *default
-  database: okuribon_development
+  primary:
+    <<: *default
+    database: okuribon_development
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: okuribon
+    # The specified database role being used to connect to PostgreSQL.
+    # To create additional roles in PostgreSQL see `$ createuser --help`.
+    # When left blank, PostgreSQL will use the default role. This is
+    # the same name as the operating system user running Rails.
+    #username: okuribon
 
-  # The password associated with the PostgreSQL role (username).
-  #password:
+    # The password associated with the PostgreSQL role (username).
+    #password:
 
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
+    # Connect on a TCP socket. Omitted by default since the client uses a
+    # domain socket that doesn't need configuration. Windows does not have
+    # domain sockets, so uncomment these lines.
+    #host: localhost
 
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
+    # The TCP port the server listens on. Defaults to 5432.
+    # If your server runs on a different port number, change accordingly.
+    #port: 5432
 
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
+    # Schema search path. The server defaults to $user,public
+    #schema_search_path: myapp,sharedapp,public
 
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+    # Minimum log levels, in increasing order:
+    #   debug5, debug4, debug3, debug2, debug1,
+    #   log, notice, warning, error, fatal, and panic
+    # Defaults to warning.
+    #min_messages: notice
+  # Solid Queue のテーブルは production と同じく別のデータベースに置く。
+  # 主のデータベースに相乗りさせると db/schema.rb にジョブのテーブルが並び、
+  # production だけ別という食い違いも残る。
+  #
+  # DATABASE_URL は primary という名前の設定にしかマージされないため、
+  # queue には接続先を url で明示する。database: は yml の値が優先され、
+  # DATABASE_URL が無い環境では url ごと落ちて default の既定に戻る。
+  queue: &queue
+    <<: *default
+    database: okuribon_development_queue
+    migrations_paths: db/queue_migrate
+    url: <%= ENV["DATABASE_URL"] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: okuribon_test
+  primary:
+    <<: *default
+    database: okuribon_test
+  queue:
+    <<: *queue
+    database: okuribon_test_queue
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,12 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # ジョブは production と同じ経路で動かす。Rails 既定の :async は
+  # プロセス内のスレッドで走るため、キューに積まれたことも失敗したことも残らない。
+  # ワーカーは bin/dev が SOLID_QUEUE_IN_PUMA=true で Puma の中に立てる
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Highlight code that triggered redirect in logs.
   config.action_dispatch.verbose_redirect_logs = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,9 @@ Rails.application.configure do
   # テスト DB に守るべきデータは無いので、鍵を秘密にする意味もない
   config.active_record.encryption.primary_key = 'test-primary-key'
   config.active_record.encryption.key_derivation_salt = 'test-key-derivation-salt'
+
+  # ジョブのアダプタは Rails が test 環境で :test にする。積むところで止まるので、
+  # 実行まで見たい spec だけが perform_enqueued_jobs で回す。
+  # Solid Queue のテーブルは、アダプタを差し替えた spec から触れるよう繋いでおく
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -9,7 +9,16 @@
 #     priority: 2
 #     schedule: at 5am every day
 
-production:
+shared: &shared
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+# 開発でも同じ定期実行を読ませる。定期実行が設定から拾われているかは
+# solid_queue_recurring_tasks の行でしか分からず、production にしか
+# 定義が無いと、手元では締切前のリマインド（#44）を確かめる足場が無い
+development:
+  <<: *shared
+
+production:
+  <<: *shared

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1127,6 +1127,27 @@ project_id は `d4c7c96c-beb2-4f1b-9128-5326c3412668`。
   実名で登録している人が多いプロバイダもあるため、参加者一覧に出す名前は本人が決められる必要がある。
   表示名の重複は許す。顔見知りの少人数で使うため、同名はアバターと本の登録内容で見分けが付く
 - メールは送らない。通知は Webhook のみ
+- 非同期処理と定期実行は Solid Queue。ワーカーは専用のプロセスを持たず、
+  `SOLID_QUEUE_IN_PUMA=true` で Puma の中に立てる。サーバーは1台で、
+  Web とジョブの負荷が競合するほどの量は流れない
+- ジョブのテーブルは、どの環境でも主のデータベースと分けた別のデータベースに置く。
+  主のデータベースに相乗りさせると、交換会のテーブルと同じ `db/schema.rb` に
+  ジョブのテーブルが並ぶ。production だけ別という食い違いも残る。
+  `DATABASE_URL` は `primary` という名前の設定にしかマージされないため、
+  development と test の queue には `config/database.yml` で接続先を明示する
+- ジョブの引数は queue のデータベースに平文で残る。ログのフィルタ（`filter_parameters`）は
+  ここに効かない。ギフトコードと招待トークンをジョブの引数に渡さない。
+  ジョブには本や交換会の id を渡し、必要な値はジョブの中で取り出す
+- 開発環境も production と同じ Solid Queue で動かす。Rails 既定の `:async` は
+  プロセス内のスレッドで走り、積まれたことも失敗したことも残らないため、
+  通知が飛ばなかったときに見るものが無くなる
+- 定期実行の定義は development にも置く。定義が拾われたかどうかは
+  `solid_queue_recurring_tasks` の行でしか分からず、production にしか定義が無いと
+  手元に確かめる足場が無い
+- test 環境ではジョブを実行せず、積まれたところで止める（Rails 既定の `:test`）。
+  通知の spec が見たいのは「送ろうとしたこと」で、実行まで見たい spec だけが
+  明示的に回す。設定ファイルの誤りは起動するまで分からないため、
+  `config/queue.yml` と `config/recurring.yml` が読めることは spec で固定する
 
 上記により、Rails 標準のうち Active Storage / Action Mailer / Action Mailbox / Action Text は使わない。
 `config/application.rb` で railtie ごと読み込まない。必要になった時点で戻す。

--- a/spec/config/solid_queue_spec.rb
+++ b/spec/config/solid_queue_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 通知（7.）はジョブとして走る。設定ファイルの誤りは Puma を起動するまで
+# 分からず、起動しても supervisor のログにしか出ない。ここで固定しておく。
+RSpec.describe 'Solid Queue の設定' do
+  it 'ワーカーとディスパッチャの構成が読める' do
+    configuration = SolidQueue::Configuration.new
+
+    expect(configuration).to be_valid, -> { configuration.errors.full_messages.join("\n") }
+    expect(configuration.configured_processes).not_to be_empty
+  end
+
+  it 'ジョブのテーブルを主のデータベースと分けている' do
+    queue = SolidQueue::Record.connection_db_config
+    primary = ApplicationRecord.connection_db_config
+
+    expect(queue.name).to eq('queue')
+    expect(queue.database).not_to eq(primary.database)
+  end
+
+  # recurring.yml は環境ごとに節が分かれ、実行時に読まれるのは自分の節だけになる。
+  # 定期実行が要るのは production なので、test 環境から全部の節を検査する
+  describe '定期実行の定義' do
+    subject(:definitions) do
+      YAML.safe_load(ERB.new(Rails.root.join('config/recurring.yml').read).result, aliases: true)
+    end
+
+    it 'すべて定期実行として読める' do
+      definitions.each do |environment, tasks|
+        tasks.each do |key, options|
+          task = SolidQueue::RecurringTask.from_configuration(key, **options.symbolize_keys)
+
+          expect(task).to be_valid, -> { "#{environment} の #{key}: #{task.errors.full_messages.join(', ')}" }
+          expect(task.next_time).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'ジョブの積まれ方' do
+    before do
+      stub_const('EchoJob', Class.new(ApplicationJob) do
+        cattr_accessor :performed, default: []
+
+        def perform(word)
+          self.class.performed << word
+        end
+      end)
+    end
+
+    # 積んだ時点で走ってしまうと、通知の spec が「送ろうとしたこと」を検査できなくなる
+    it 'test 環境では積むだけのアダプタを使う' do
+      expect(ActiveJob::Base.queue_adapter).to be_a(ActiveJob::QueueAdapters::TestAdapter)
+    end
+
+    context '積んだだけのとき' do
+      include ActiveJob::TestHelper
+
+      it '実行されないまま待つ' do
+        expect { EchoJob.perform_later('こんにちは') }.to have_enqueued_job(EchoJob).with('こんにちは')
+        expect(EchoJob.performed).to be_empty
+      end
+
+      it '明示的に回せば実行される' do
+        perform_enqueued_jobs { EchoJob.perform_later('こんにちは') }
+
+        expect(EchoJob.performed).to eq(['こんにちは'])
+      end
+    end
+
+    context 'Solid Queue のアダプタで積んだとき' do
+      before { EchoJob.queue_adapter = :solid_queue }
+
+      it 'ワーカーが拾える実行待ちの行になる' do
+        expect { EchoJob.perform_later('こんにちは') }.to change(SolidQueue::ReadyExecution, :count).by(1)
+
+        job = SolidQueue::Job.last
+        expect(job.class_name).to eq('EchoJob')
+        expect(job.arguments['arguments']).to eq(['こんにちは'])
+      end
+    end
+  end
+end

--- a/spec/config/solid_queue_spec.rb
+++ b/spec/config/solid_queue_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe 'Solid Queue の設定' do
       YAML.safe_load(ERB.new(Rails.root.join('config/recurring.yml').read).result, aliases: true)
     end
 
+    it '開発と本番の両方にある' do
+      expect(definitions['development']).to be_present
+      expect(definitions['production']).to be_present
+    end
+
     it 'すべて定期実行として読める' do
       definitions.each do |environment, tasks|
         tasks.each do |key, options|


### PR DESCRIPTION
非同期処理と定期実行の基盤として Solid Queue を動かした。通知（7.）が乗る土台で、
この PR ではジョブそのものは足していない。

## 変えたこと

- **ジョブのテーブルを別のデータベースに置いた**（development / test）。production は
  もともと別だった。主のデータベースに相乗りさせると `db/schema.rb` にジョブのテーブルが
  並び、production だけ別という食い違いも残る
- **`DATABASE_URL` は `primary` という名前の設定にしかマージされない**ため、queue には
  `url` で接続先を明示した。`QUEUE_DATABASE_URL` を devcontainer と CI に足す手もあるが、
  環境変数を増やさないほうを採った。`database:` は yml の値が優先され、`DATABASE_URL` が
  無い環境では `url` ごと落ちて既定に戻ることを確かめてある
- **development のアダプタを `:solid_queue` にした。** Rails 既定の `:async` はプロセス内の
  スレッドで走り、積まれたことも失敗したことも残らない
- **`Procfile.dev` の web に `SOLID_QUEUE_IN_PUMA=true` を付けた。** `bin/dev` で立てた Puma の
  中にワーカーが立つ。`bin/rails server` を直に叩いた場合は立たないことを README に書いた
- **定期実行の定義を development にも置いた。** 雛形が production にだけ持っていた掃除の定義を
  アンカーに切り出して共有した。定義が拾われたかは `solid_queue_recurring_tasks` の行にしか
  出ないため、production だけだと手元に確かめる足場が無い
- **`docs/spec.md` 11.** にジョブ基盤の判断を書き足した。ジョブの引数は queue のデータベースに
  平文で残り `filter_parameters` が効かないため、ギフトコードと招待トークンを引数に渡さない、
  という1行を含む

## 完了条件

- [x] ジョブをキューに積むと実行される — 開発環境で `SolidQueue::RecurringJob` を積み、
  worker が拾って `Performed`、`finished_at` が入るところまで確認
- [x] `SOLID_QUEUE_IN_PUMA=true` で Puma 起動時にワーカーが立ち上がる — supervisor /
  dispatcher / worker / scheduler の登録をログで確認
- [x] 定期実行（recurring）の設定が読み込まれる — 起動時に scheduler が
  `recurring_schedule: ["clear_solid_queue_finished_jobs"]` で立ち、
  `solid_queue_recurring_tasks` に行が入ることを確認
- [x] 開発環境でジョブの実行を確認できる — 確かめ方を README に書いた
- [x] test 環境でジョブが同期実行されるか、明示的に検査できる — Rails 既定の `:test` を
  spec で固定し、`perform_enqueued_jobs` で回せることも spec にした

## spec

`spec/config/solid_queue_spec.rb` を足した。設定ファイルの誤りは Puma を起動するまで
分からないため、`config/queue.yml` と `config/recurring.yml` が読めることを固定している。
`threads` と `fibers` の併記、`schedule` の不正な値のそれぞれで落ちることを確かめたうえで
戻してある。

ジョブの積まれ方は同じファイルに置いた。`:solid_queue` に差し替えて積むと queue の
データベースに実行待ちの行ができることまで見ている。

## 参照していない資料

画面を作る・変える変更が無いため、ビジュアルガイドは参照していない。

closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)