### PR TITLE
参加から交換会を引く入口を concern に集める

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < ApplicationController
+  include ParticipatingExchange
   include PhaseGuard
 
   before_action :require_login
@@ -48,13 +49,6 @@ class BooksController < ApplicationController
   end
 
   private
-
-  # 交換会は参加から引く。参加していなければ見つからない。
-  # 読み取りと書き込みで入口を分けると、片方だけ緩む
-  def set_participation
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
-    @exchange = @participation.exchange
-  end
 
   # フェーズの判定対象。PhaseGuard から呼ばれる
   def current_exchange

--- a/app/controllers/concerns/participating_exchange.rb
+++ b/app/controllers/concerns/participating_exchange.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# ログイン中の利用者の参加から交換会を引く。
+#
+# 交換会そのものを引いて権限を後から見るのではなく、参加を引いて交換会を辿る。
+# 参加していなければ見つからず、403 ではなく 404 になる。403 を返すと、
+# 招待されていない交換会の実在が URL を試すだけで分かる（docs/spec.md 8.）。
+#
+# 読み取りと書き込みで入口を分けない。口ごとに条件を手書きすると、
+# 口を足したときに片方だけ緩む
+module ParticipatingExchange
+  extend ActiveSupport::Concern
+
+  private
+
+  # ネストされた口は :exchange_id、交換会そのものを開く口は :id と、
+  # ルートのキーだけが違う。取り出しは呼ぶ側に任せ、引き方はここに1つだけ置く
+  def set_participation(exchange_id = params.expect(:exchange_id))
+    @participation = current_user.participations.find_by!(exchange_id:)
+    @exchange = @participation.exchange
+  end
+end

--- a/app/controllers/exchanges_controller.rb
+++ b/app/controllers/exchanges_controller.rb
@@ -2,6 +2,7 @@
 
 class ExchangesController < ApplicationController
   include BookListing
+  include ParticipatingExchange
 
   before_action :require_login
 
@@ -19,8 +20,8 @@ class ExchangesController < ApplicationController
   # 権限の判定と取り出しを1回で済ませる。
   # 読み取りは5フェーズすべてで開いており、止めるのは書き込みだけ（4. フェーズ）
   def show
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:id))
-    @exchange = @participation.exchange
+    # ネストされた口と違い、ここだけ交換会 id が :id で来る
+    set_participation(params.expect(:id))
     # 状態ヘッダーの「あなたがすること」。フェーズだけでは決まらず自分の状態で
     # 変わるので、組み立てはサービスに置く（交換会一覧も同じ文言を並べる）
     @todo = Exchanges::Todo.new(@participation, at: requested_at).call

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -7,14 +7,12 @@
 # 取り出し口が無い。取得経路そのものは Book#gift_code_for に集約してあり、
 # この画面は「並べる対象を絞る」ことだけを受け持つ
 class ResultsController < ApplicationController
+  include ParticipatingExchange
+
   before_action :require_login
+  before_action :set_participation
 
-  # 交換会は参加から引く。参加していなければ見つからない。
-  # 本の一覧や交換会トップと同じ入口にして、画面ごとに条件を手書きしない
   def show
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
-    @exchange = @participation.exchange
-
     return render_unpublished unless @exchange.published?(at: requested_at)
 
     # 冊数と中身の両方を見るので、ここで読み切る。
@@ -40,7 +38,7 @@ class ResultsController < ApplicationController
   # 素の 404 だと、参加者が自分の交換会で行き止まりに当たり、URL を間違えたのか
   # 時期が早いのかを区別できない。実在を伏せる必要があるのは主催者専用の画面だけで
   # （docs/spec.md 8.）、ここへ来られるのは交換会もフェーズも既に見えている参加者。
-  # 参加していない人には find_by! が先に落ち、素の 404 が返る
+  # 参加していない人には ParticipatingExchange が先に落ち、素の 404 が返る
   def render_unpublished
     render :unpublished, status: :not_found
   end

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -4,6 +4,7 @@
 # ここでは順序だけをまとめて受け取る（docs/spec.md 6.2 / #27）
 class WishListsController < ApplicationController
   include BookListing
+  include ParticipatingExchange
 
   before_action :require_login
   before_action :set_participation
@@ -16,14 +17,5 @@ class WishListsController < ApplicationController
     @participation.reorder_wishes!(params.expect(book_ids: []), at: requested_at)
 
     render_listing
-  end
-
-  private
-
-  # 交換会は参加から引く。参加していなければ見つからない。
-  # 本の一覧と同じ入口にする。読み取りと書き込みで分けると、片方だけ緩む
-  def set_participation
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
-    @exchange = @participation.exchange
   end
 end

--- a/app/controllers/wishes_controller.rb
+++ b/app/controllers/wishes_controller.rb
@@ -4,6 +4,7 @@
 # 並べ替えは順序だけをまとめて送る（docs/spec.md 6.2 / #27）
 class WishesController < ApplicationController
   include BookListing
+  include ParticipatingExchange
 
   before_action :require_login
   before_action :set_participation
@@ -29,13 +30,6 @@ class WishesController < ApplicationController
   end
 
   private
-
-  # 交換会は参加から引く。参加していなければ見つからない。
-  # 本の一覧と同じ入口にする。読み取りと書き込みで分けると、片方だけ緩む
-  def set_participation
-    @participation = current_user.participations.find_by!(exchange_id: params.expect(:exchange_id))
-    @exchange = @participation.exchange
-  end
 
   # 本も交換会から引く。別の交換会の本を渡されても見つからない。
   # 希望リストが交換会をまたぐと、取得枠の勘定が成り立たない

--- a/spec/requests/concerns/participating_exchange_spec.rb
+++ b/spec/requests/concerns/participating_exchange_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# 参加から交換会を引く入口を、仕組み単体で確かめる。
+# 実際のコントローラは5つあり、そのうち1つだけルートのキーが :id で違う。
+# ここでは concern を載せた最小のものを2つ立て、キーの違いを跨いで同じ入口を通ることを見る
+RSpec.describe ParticipatingExchange do
+  let!(:user) { create(:user) }
+  let!(:exchange) { create(:exchange) }
+  let!(:participation) { create(:participation, user:, exchange:) }
+
+  # ネストされた口（:exchange_id）と、単独の口（:id）の2つを立てる。
+  # 引いたものを本文に出し、どちらの口でも同じ参加に辿り着くことを見る
+  before do
+    log_in_as(user)
+
+    nested = Class.new(ApplicationController) do
+      include ParticipatingExchange
+
+      before_action :require_login
+      before_action :set_participation
+
+      def show
+        render plain: [@participation.id, @exchange.id].join(',')
+      end
+    end
+
+    singular = Class.new(ApplicationController) do
+      include ParticipatingExchange
+
+      before_action :require_login
+
+      def show
+        set_participation(params.expect(:id))
+
+        render plain: [@participation.id, @exchange.id].join(',')
+      end
+    end
+
+    stub_const('NestedParticipatingTestController', nested)
+    stub_const('SingularParticipatingTestController', singular)
+
+    Rails.application.routes.draw do
+      get '/participating_test/exchanges/:exchange_id/nested' => 'nested_participating_test#show'
+      get '/participating_test/exchanges/:id' => 'singular_participating_test#show'
+
+      # ログインしていない人の行き先（Authentication が引く）
+      root 'exchanges#index'
+    end
+  end
+
+  after { Rails.application.reload_routes! }
+
+  it '参加している交換会は、その参加とともに引ける' do
+    get "/participating_test/exchanges/#{exchange.id}/nested"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("#{participation.id},#{exchange.id}")
+  end
+
+  # 参加していない人に 403 を返すと、その交換会が実在することが URL を試すだけで分かる
+  it '参加していない交換会は見つからない' do
+    other = create(:exchange)
+
+    get "/participating_test/exchanges/#{other.id}/nested"
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  # 実在しない id と、実在するが参加していない交換会の応答が同じであること。
+  # 分かれると、参加していない交換会の実在が応答の違いから読める
+  it '存在しない交換会も見つからない' do
+    get '/participating_test/exchanges/0/nested'
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  # 交換会そのものを開く口だけルートのキーが :id になる。
+  # 口ごとに条件を手書きしないために、キーだけを呼ぶ側から渡す
+  it '交換会 id を渡す口も同じ入口を通る' do
+    get "/participating_test/exchanges/#{exchange.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("#{participation.id},#{exchange.id}")
+  end
+
+  it '交換会 id を渡す口でも、参加していなければ見つからない' do
+    other = create(:exchange)
+
+    get "/participating_test/exchanges/#{other.id}"
+
+    expect(response).to have_http_status(:not_found)
+  end
+end


### PR DESCRIPTION
「ログイン中の利用者の参加から交換会を引く」入口が5箇所に重複していたので、`ParticipatingExchange` に集めました。

closes #179

## 変えたこと

`app/controllers/concerns/participating_exchange.rb` に `set_participation` を1つだけ置き、次の5箇所がそこを通るようにしました。

- `BooksController` / `WishesController` / `WishListsController` — `before_action :set_participation` はそのまま。定義だけが concern へ移動
- `ExchangesController#show` — インラインをやめ、`set_participation(params.expect(:id))` を呼ぶ
- `ResultsController#show` — インラインをやめ、`before_action :set_participation` に寄せた

「参加から引くので、参加していなければ 404」という決めごとが1箇所になり、口を足したときに片方だけ緩む余地が消えます。

## 交換会 id の渡し方

5つのうち `ExchangesController#show` だけルートが `/exchanges/:id` で、パラメータのキーが `:exchange_id` ではありません。concern 側は既定を `params.expect(:exchange_id)` としつつ引数で受け取る形にし、この口だけが明示的に `:id` を渡します。

`exchange_id_param` のようなフックを挟んで差し替える案は採りませんでした。呼ぶ側が何を渡しているかがその場から読めなくなるためです。

## 寄せなかったもの

`BooksController#current_exchange`（`PhaseGuard` へ `@exchange` を返すだけのメソッド）は残しました。concern 側に置くと、参加を引く仕組みとフェーズを見る仕組みが暗黙に結び付きます。

## 検証

- `bin/rspec` — 1071 examples, 0 failures
- `bin/rubocop` — no offenses
- `bin/ci` — 通過

振る舞いは変えていません。5つの口の 404 は既存の request spec が押さえており、そのうえで concern 単体の spec を `spec/requests/concerns/participating_exchange_spec.rb` に足しました（`PhaseGuard` と同じく、最小のコントローラを立てて回す形）。

画面には触っていないため、ビジュアルガイドの参照は不要でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)