### PR TITLE
system spec の足場を入れ、希望リストの並べ替えを押さえる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,10 @@ jobs:
       - name: Prepare database
         run: bin/rails db:prepare
 
-      # system spec は本物のブラウザで開くので、スタイルシートが無いと
-      # 描画そのものが 500 になる。ビルド済みの CSS は追跡していない
+      # ビルド済みの CSS は追跡していない。system spec は本物のブラウザで開くので、
+      # 無いまま走らせると描画そのものが 500 になる
       - name: Build stylesheet
         run: bin/rails tailwindcss:build
 
-      # ブラウザは ubuntu-latest 同梱の google-chrome を PATH から拾う。
-      # cuprite が CDP で直に繋ぐので、chromedriver は入れない
       - name: Run tests
         run: bin/rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,12 @@ jobs:
       - name: Prepare database
         run: bin/rails db:prepare
 
+      # system spec は本物のブラウザで開くので、スタイルシートが無いと
+      # 描画そのものが 500 になる。ビルド済みの CSS は追跡していない
+      - name: Build stylesheet
+        run: bin/rails tailwindcss:build
+
+      # ブラウザは ubuntu-latest 同梱の google-chrome を PATH から拾う。
+      # cuprite が CDP で直に繋ぐので、chromedriver は入れない
       - name: Run tests
         run: bin/rspec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,19 @@ MCP が使えずガイドを開けなかったときは、そのまま進めな�
 DB を伴う rake タスクは `RAILS_ENV` を明示する。
 `DATABASE_URL` は現在の環境の設定にしかマージされないため、`RAILS_ENV=test` を付けないと test の接続先が解決されない。
 
+### system spec
+
+`spec/system` は `bin/rspec` に含まれる。別のコマンドは無い。
+
+本物のブラウザで開くので、スタイルシートが要る。
+`app/assets/builds/tailwind.css` は追跡していないため、
+無ければ `RAILS_ENV=test bin/rails tailwindcss:build` で作る。
+無いまま走らせると、画面が 500 になって落ちる。
+
+ブラウザは Chrome を CDP で直に動かす（cuprite）。chromedriver は入れない。
+devcontainer は Playwright MCP のために入れた Chromium を `~/.cache/ms-playwright` から拾い、
+CI は `ubuntu-latest` 同梱の `google-chrome` を PATH から拾う。
+
 ## issue とブランチ
 
 タスクは GitHub issue で管理する。ラベルは2種類。

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,12 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails'
 
+  # JavaScript が動いて初めて成立する振る舞いを押さえる system spec 用。
+  # cuprite は CDP で Chrome に直接繋ぐので、chromedriver を持たずに済む。
+  # selenium は版の合う chromedriver をテストのたびに引いてくる
+  gem 'capybara'
+  gem 'cuprite'
+
   # 通知の Webhook を spec から本当に叩かないための封じ。
   # 送信サービスに口を差し込むだけでは、そこを通らない経路が塞がらない
   gem 'webmock', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,7 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails'
 
-  # JavaScript が動いて初めて成立する振る舞いを押さえる system spec 用。
-  # cuprite は CDP で Chrome に直接繋ぐので、chromedriver を持たずに済む。
-  # selenium は版の合う chromedriver をテストのたびに引いてくる
+  # system spec 用。cuprite は CDP で Chrome に直接繋ぐので、chromedriver を持たない
   gem 'capybara'
   gem 'cuprite'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,12 +94,24 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
     crass (1.0.7)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -125,6 +137,12 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     fugit (1.13.0)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -172,6 +190,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -432,10 +451,13 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.2)
     websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.8.3)
 
 PLATFORMS
@@ -452,6 +474,8 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundler-audit
+  capybara
+  cuprite
   debug
   factory_bot_rails
   faker
@@ -508,10 +532,12 @@ CHECKSUMS
   brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
+  cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
@@ -526,6 +552,7 @@ CHECKSUMS
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
   fugit (1.13.0) sha256=a4f093fce740da52f216740a5041e2a594ea763cdb89e8b2754ca4399634ab18
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
@@ -543,6 +570,7 @@ CHECKSUMS
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.4) sha256=4411c22d350dd1c20250f7eada3cca2695438c2f769cf0782f0cd065d90a3e7b
@@ -641,8 +669,10 @@ CHECKSUMS
   version_gem (1.1.14) sha256=6b7306c7e9416d06067561981ab3444e2cecb844f26cc325ae3c27b44cf85613
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
 
 BUNDLED WITH

--- a/docs/decisions/0020-system-spec-driver-cuprite.md
+++ b/docs/decisions/0020-system-spec-driver-cuprite.md
@@ -1,0 +1,55 @@
+# 0020 system spec の足場を cuprite で組む
+
+- 日付：2026-08-22
+- 発端：issue #194
+
+## 決めたこと
+
+Capybara のドライバに cuprite を使い、Chrome へ CDP で直に繋ぐ。chromedriver は持たない。
+ブラウザの実行ファイルは、devcontainer が `~/.cache/ms-playwright` の Chromium、
+CI が `ubuntu-latest` 同梱の `google-chrome` を PATH から拾う。
+
+`--no-sandbox`（ferrum の `dockerize`）を常に付ける。
+
+WebMock の localhost 遮断を解く。
+
+並べ替えが送られたことは、コントローラの `process_action` 通知に届いた `book_ids` で見る。
+
+## なぜ
+
+CDP は Chrome が自分で備えている通信規約なので、間に立つ実行ファイルが要らない。
+chromedriver を挟むと、ブラウザの版に合わせて別の実行ファイルを用意することになる。
+
+`--no-sandbox` は devcontainer と `ubuntu-latest` の両方で要る。どちらも非特権の
+user namespace を作れず、Chrome は sandbox を張れないまま起動に失敗する。
+環境で出し分けても、付けない側が使われる場面が無い。
+
+localhost を通すのは、ferrum が繋ぎ先を決めるのに CDP の待ち受けポートへ
+Net::HTTP で問い合わせるため。通知先のホストは localhost ではないので、
+本物の Webhook を叩かせない目的のほうは満たされたままになる。
+
+送られたことをコントローラの通知で見るのは、画面からは読めないため。
+並びは送る前から JavaScript が動かしているので、動かした並びと返ってきた並びを
+画面の中身で見分けられない。
+
+## 却下した代替案
+
+- **Capybara + selenium。** Rails の既定で、Selenium Manager が版の合う chromedriver を
+  引いてくるので手で揃える作業は起きない。ただしテストのたびにドライバの取得が挟まり、
+  取得できるかどうかが実行環境の外に出る
+- **playwright-ruby-client。** devcontainer に入っている Chromium は Playwright のものなので
+  相性はよいが、ブラウザを動かす実体が Node 側に移り、テスト環境がもう1つ増える
+- **ブラウザを CI と devcontainer で別々に用意して版を固定する。** どちらの環境にも
+  すでに Chrome がある。取ってくるものを増やすと、その取得が落ちたときに
+  差分と無関係な赤が出る
+- **保存された `Wish` の並びを見て、送られたことを確かめる。** 順位の振り直しは
+  `Participation#reorder_wishes!` の spec が持っている。同じ判定を2か所で見ると、
+  片方だけ直したときに食い違う
+- **WebMock の `allow` に CDP のポートだけを並べる。** 待ち受けポートは起動のたびに変わる
+
+## 影響する場所
+
+- `spec/support/system.rb`
+- `spec/support/webmock.rb`
+- `CLAUDE.md`「検証 > system spec」
+- `.github/workflows/ci.yml`

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 
-# request spec でログイン状態を作る。
+# spec でログイン状態を作る。
 # セッションを直に書けないため、実際の OAuth コールバックを通す。
 # 認証情報は利用者のレコードから組み立てるので、from_omniauth は
 # 新しく作らずにその利用者を引き当てる
 module AuthenticationHelper
-  def log_in_as(user)
+  private
+
+  def mock_omniauth_as(user)
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
       provider: user.provider,
       uid: user.uid,
       info: { name: user.display_name, image: user.avatar_url }
     )
+  end
+end
+
+module RequestAuthenticationHelper
+  include AuthenticationHelper
+
+  def log_in_as(user)
+    mock_omniauth_as(user)
 
     get oauth_callback_path
   end
@@ -20,6 +30,18 @@ module AuthenticationHelper
   end
 end
 
+# 踏むコールバックは request spec と同じで、踏み方だけがブラウザになる
+module SystemAuthenticationHelper
+  include AuthenticationHelper
+
+  def log_in_as(user)
+    mock_omniauth_as(user)
+
+    visit oauth_callback_path
+  end
+end
+
 RSpec.configure do |config|
-  config.include AuthenticationHelper, type: :request
+  config.include RequestAuthenticationHelper, type: :request
+  config.include SystemAuthenticationHelper, type: :system
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -30,7 +30,6 @@ module RequestAuthenticationHelper
   end
 end
 
-# 踏むコールバックは request spec と同じで、踏み方だけがブラウザになる
 module SystemAuthenticationHelper
   include AuthenticationHelper
 

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -5,9 +5,8 @@ require 'capybara/cuprite'
 module SystemSpecBrowser
   module_function
 
-  # devcontainer には Playwright MCP のために入れた Chromium があるが、PATH には無い。
-  # CI（ubuntu-latest）は google-chrome を PATH に持つので、そちらは nil を返して
-  # ferrum に探させる。Playwright は版ごとにディレクトリを分けるため、新しいほうを取る
+  # 見つからなければ nil を返し、ferrum に PATH から探させる。
+  # Playwright はバージョンごとにディレクトリを分けるため、新しいほうを取る
   def path
     Dir.glob(File.expand_path('~/.cache/ms-playwright/chromium-*/chrome-linux*/chrome')).max
   end
@@ -25,8 +24,7 @@ RSpec.configure do |config|
     # dockerize は --no-sandbox を足す。devcontainer も ubuntu-latest も
     # 非特権の user namespace を作れず、Chrome は sandbox を張れないまま落ちる。
     #
-    # js_errors は既定で偽。JavaScript が落ちても素通りするなら、
-    # JavaScript の振る舞いを押さえるための spec が何も守らない
+    # js_errors は既定で false。既定のままだと、JavaScript が落ちても例は通る
     driven_by :cuprite,
               screen_size: [1400, 1000],
               options: { browser_path: SystemSpecBrowser.path, dockerize: true,

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'capybara/cuprite'
+
+module SystemSpecBrowser
+  module_function
+
+  # devcontainer には Playwright MCP のために入れた Chromium があるが、PATH には無い。
+  # CI（ubuntu-latest）は google-chrome を PATH に持つので、そちらは nil を返して
+  # ferrum に探させる。Playwright は版ごとにディレクトリを分けるため、新しいほうを取る
+  def path
+    Dir.glob(File.expand_path('~/.cache/ms-playwright/chromium-*/chrome-linux*/chrome')).max
+  end
+end
+
+# 保存は SAVE_DELAY のぶん待ってから送られる。既定の2秒だと、
+# 往復のたびに余裕が1秒台しか残らない
+Capybara.default_max_wait_time = 5
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    # 希望リストが一覧の右に開くのは lg（1024px）から。狭い画面で走らせると、
+    # 希望リストに触るどの spec も、先にシートを開く操作を挟むことになる。
+    #
+    # dockerize は --no-sandbox を足す。devcontainer も ubuntu-latest も
+    # 非特権の user namespace を作れず、Chrome は sandbox を張れないまま落ちる。
+    #
+    # js_errors は既定で偽。JavaScript が落ちても素通りするなら、
+    # JavaScript の振る舞いを押さえるための spec が何も守らない
+    driven_by :cuprite,
+              screen_size: [1400, 1000],
+              options: { browser_path: SystemSpecBrowser.path, dockerize: true,
+                         js_errors: true, process_timeout: 30 }
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -4,5 +4,9 @@ require 'webmock/rspec'
 
 # 通知は外部の Webhook へ POST する。spec がうっかり本物の URL を叩くと、
 # 手元の実行がチャンネルに届いてしまう。登録していない通信はすべて落とす。
-# 送信サービスを差し替えられるようにするだけでは、そこを通らない経路が残る
-WebMock.disable_net_connect!(allow_localhost: false)
+# 送信サービスを差し替えられるようにするだけでは、そこを通らない経路が残る。
+#
+# localhost だけは通す。system spec のブラウザを起こす ferrum が、
+# 繋ぎ先を決めるのに CDP の待ち受けポートへ Net::HTTP で問い合わせる。
+# 通知先のホストは localhost ではないので、塞ぎたいものは塞がったまま
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/system/wish_reorder_spec.rb
+++ b/spec/system/wish_reorder_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe '希望リストの並べ替え' do
-  # 並べ替えが動くのは希望提出期間だけなので、trait はここで指定する
   let!(:exchange) { create(:exchange, :wish) }
   let!(:participation) { create(:participation, exchange:) }
   # 本ごとに登録者を分ける。自分が登録した本は希望に選べない
@@ -13,7 +12,6 @@ RSpec.describe '希望リストの並べ替え' do
     end
   end
 
-  # 送られた並びは book_ids で届く。画面から読めるのは題なので、突き合わせる側も題に直す
   let!(:sent_orders) { [] }
 
   before do
@@ -30,6 +28,7 @@ RSpec.describe '希望リストの並べ替え' do
 
   around do |example|
     orders = sent_orders
+    # 届くのは book_ids。画面から読めるのは題なので、突き合わせる側も題に直す
     titles = ->(ids) { Book.where(id: ids).index_by(&:id).values_at(*ids.map(&:to_i)).map(&:title) }
 
     subscription = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*, payload|
@@ -74,9 +73,8 @@ RSpec.describe '希望リストの並べ替え' do
     expect(sent_orders).to eq([['青の本', '緑の本', '赤の本']])
   end
 
-  # 保存の往復は画面に現れない。並びは送る前から動いているので、
-  # 動かした並びと返ってきた並びを画面の中身では見分けられない。
-  # 差し替わる区画に印を付けて、それが消えるのを待つ
+  # 並びは送る前から動いているので、動かした並びと返ってきた並びを画面の中身では
+  # 見分けられない。差し替わる区画に印を付けて、それが消えるのを待つ
   def saving_wish_list
     page.execute_script("document.getElementById('wish_list').dataset.pending = ''")
 
@@ -122,8 +120,7 @@ RSpec.describe '希望リストの並べ替え' do
     end
   end
 
-  # 掴んでいたハンドルは行と一緒に動くので、戻り先は行の位置で見る。
-  # ハンドル以外に focus があれば 0 を返す
+  # 掴んでいたハンドルは行と一緒に動くので、戻り先は行の位置で見る
   def focused_handle_position
     page.evaluate_script(<<~JS)
       (() => {

--- a/spec/system/wish_reorder_spec.rb
+++ b/spec/system/wish_reorder_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '希望リストの並べ替え' do
+  # 並べ替えが動くのは希望提出期間だけなので、trait はここで指定する
+  let!(:exchange) { create(:exchange, :wish) }
+  let!(:participation) { create(:participation, exchange:) }
+  # 本ごとに登録者を分ける。自分が登録した本は希望に選べない
+  let!(:books) do
+    ['赤の本', '青の本', '緑の本'].map do |title|
+      create(:book, title:, participation: create(:participation, exchange:))
+    end
+  end
+
+  # 送られた並びは book_ids で届く。画面から読めるのは題なので、突き合わせる側も題に直す
+  let!(:sent_orders) { [] }
+
+  before do
+    books.each_with_index { |book, index| create(:wish, participation:, book:, position: index + 1) }
+
+    log_in_as(participation.user)
+    visit exchange_path(exchange)
+
+    # ハンドルが押せるようになるのは Stimulus が繋がってから。
+    # 繋がる前に触ると、どの例も disabled のボタンを相手にすることになる。
+    # 説明の hidden が外れるのが同じ connect なので、見えるまで待つ
+    find('#wish_reorder_help')
+  end
+
+  around do |example|
+    orders = sent_orders
+    titles = ->(ids) { Book.where(id: ids).index_by(&:id).values_at(*ids.map(&:to_i)).map(&:title) }
+
+    subscription = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*, payload|
+      orders << titles.call(payload[:params].fetch('book_ids')) if payload[:controller] == 'WishListsController'
+    end
+
+    example.run
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  it 'ドラッグで動かした並びをサーバーへ送る' do
+    saving_wish_list { drag_past_next_row('赤の本') }
+
+    expect(sent_orders).to eq([['青の本', '赤の本', '緑の本']])
+  end
+
+  it 'ハンドルにフォーカスして ↑↓ で隣と入れ替えられる' do
+    press_handle('緑の本', :up)
+
+    expect_rows('赤の本', '緑の本', '青の本')
+  end
+
+  it 'ハンドルにフォーカスして Home / End で端まで送れる' do
+    press_handle('緑の本', :home)
+
+    expect_rows('緑の本', '赤の本', '青の本')
+  end
+
+  it '動かしたあと、掴んでいたハンドルへフォーカスが戻る' do
+    saving_wish_list { press_handle('赤の本', :down) }
+
+    expect_rows('青の本', '赤の本', '緑の本')
+    expect(focused_handle_position).to eq(2)
+  end
+
+  it '続けて押したぶんを1回にまとめて送る' do
+    # 2つを1回の呼び出しで送る。呼び分けると、間が SAVE_DELAY を越えたときに
+    # まとまらなかったのか、まとめる仕掛けが壊れたのかを見分けられない
+    saving_wish_list { press_handle('赤の本', :down, :down) }
+
+    expect(sent_orders).to eq([['青の本', '緑の本', '赤の本']])
+  end
+
+  # 保存の往復は画面に現れない。並びは送る前から動いているので、
+  # 動かした並びと返ってきた並びを画面の中身では見分けられない。
+  # 差し替わる区画に印を付けて、それが消えるのを待つ
+  def saving_wish_list
+    page.execute_script("document.getElementById('wish_list').dataset.pending = ''")
+
+    yield
+
+    expect(page).to have_no_css('#wish_list[data-pending]', visible: :all)
+  end
+
+  # cuprite の send_keys は要素を先にクリックする。ハンドルの pointerdown はつまむ操作に
+  # あたり、preventDefault がフォーカスを止めるので、押したキーが本文へ逃げる。
+  # フォーカスを当てるところと、キーを送るところを分ける
+  def press_handle(title, *keys)
+    page.execute_script("#{handle_script(title)}.focus()")
+
+    page.driver.browser.keyboard.type(*keys)
+  end
+
+  # 差し込みは重ねた行の半分を越えたところで起きる。
+  # 行の高さは装飾で変わるので、越える距離はその場で測る
+  def drag_past_next_row(title)
+    distance = page.evaluate_script(<<~JS)
+      (() => {
+        const rows = [...document.querySelectorAll('[data-wish-reorder-target="row"]')];
+        const index = rows.findIndex((row) => row.textContent.includes(#{title.to_json}));
+        const from = rows[index].getBoundingClientRect();
+        const over = rows[index + 1].getBoundingClientRect();
+        return Math.ceil(over.top + over.height / 2 - (from.top + from.height / 2)) + 1;
+      })()
+    JS
+
+    # Capybara が持つのは要素から要素への drag_to だけで、行の半分を越えるだけの
+    # 距離を指せない。距離で動かす drag_by は cuprite の側にあるので base から呼ぶ。
+    # scroll: false も cuprite への指定。既定では掴む前に window ごと同じだけ流すので、
+    # 掴んだ行と重ねる行の位置関係が、測ったときから変わる
+    find('#wish_list li', text: title).find('[data-wish-reorder-target="handle"]')
+                                      .base.drag_by(0, distance, steps: 10, scroll: false)
+  end
+
+  # 差し替えの途中で読むと行が入れ替わっている最中にあたるため、待てる形で見る
+  def expect_rows(*titles)
+    titles.each_with_index do |title, index|
+      expect(page).to have_css("#wish_list li:nth-child(#{index + 1})", text: title)
+    end
+  end
+
+  # 掴んでいたハンドルは行と一緒に動くので、戻り先は行の位置で見る。
+  # ハンドル以外に focus があれば 0 を返す
+  def focused_handle_position
+    page.evaluate_script(<<~JS)
+      (() => {
+        const handles = [...document.querySelectorAll('[data-wish-reorder-target="handle"]')];
+        return handles.indexOf(document.activeElement) + 1;
+      })()
+    JS
+  end
+
+  def handle_script(title)
+    <<~JS.strip
+      [...document.querySelectorAll('[data-wish-reorder-target="handle"]')]
+        .find((handle) => handle.closest('li').textContent.includes(#{title.to_json}))
+    JS
+  end
+end


### PR DESCRIPTION
## 解決したこと

system spec を動かせるようにし、`wish_reorder` の振る舞いを押さえた。

ブラウザは cuprite で Chrome へ CDP に直に繋ぐ。chromedriver は入れていない。
実行ファイルは devcontainer が `~/.cache/ms-playwright` の Chromium、
CI が `ubuntu-latest` 同梱の `google-chrome` を PATH から拾う。
選定の経緯は `docs/decisions/0020`。

押さえたのは5つ。

- ドラッグで動かした並びをサーバーへ送る
- ↑↓ で隣と入れ替えられる
- Home / End で端まで送れる
- 動かしたあと、掴んでいたハンドルへフォーカスが戻る
- 続けて押したぶんを1回にまとめて送る（`SAVE_DELAY`）

順位の振り直しそのものは見ていない。`Participation#reorder_wishes!` の spec が持つ。

## 差分から読み取れない前提

- Chrome には `--no-sandbox`（ferrum の `dockerize`）が要る。devcontainer も
  `ubuntu-latest` も非特権の user namespace を作れず、sandbox を張れないまま起動に失敗する
- WebMock の localhost 遮断を解いた。ferrum が CDP の待ち受けポートへ Net::HTTP で
  問い合わせる。通知先のホストは localhost ではないので、塞ぎたいものは塞がったまま
- cuprite の `send_keys` は要素を先にクリックする。ハンドルの `pointerdown` はつまむ操作に
  あたり、`preventDefault` がフォーカスを止めるため、押したキーが本文へ逃げる。
  フォーカスを当てるところとキーを送るところを分けてある
- CI に `tailwindcss:build` を足した。`app/assets/builds/tailwind.css` は追跡していないので、
  無いまま system spec を走らせると画面が 500 になって落ちる

## 落ちることの確認

送信を外す・`SAVE_DELAY` を 0 にする・フォーカスの復帰を外す、の3つを手元で当て、
対応する例がそれぞれ落ちることを確かめた。

## 完了条件

- [x] devcontainer と CI の両方で system spec が1本通る（CI はこの PR の実行で確認する）
- [x] `wish_reorder` の4項目を押さえた
- [x] 順位の振り直しそのものは検証していない
- [x] `CLAUDE.md`「検証」に system spec の走らせ方を書いた
- [x] CI の `test` ジョブで system spec も走る（`bin/rspec` が `spec/system` を含む）

画面には触っていないので、ビジュアルガイドは参照していない。

closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)