### PR TITLE
残りの Stimulus controller を system spec で押さえる

### DIFF
--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -12,11 +12,22 @@ module SystemSpecBrowser
   end
 end
 
+module SystemRevertHelper
+  # 戻るまでの長さは Stimulus が data 属性から読み直すので、始める前に縮めれば効く。
+  # 既定の長さをそのまま待つと、待つぶんだけ実行時間が伸びる
+  def revert_after(controller, milliseconds)
+    find(%([data-controller~="#{controller}"]))
+      .execute_script("this.dataset.#{controller}RevertAfterValue = #{milliseconds}")
+  end
+end
+
 # 保存は SAVE_DELAY のぶん待ってから送られる。既定の2秒だと、
 # 往復のたびに余裕が1秒台しか残らない
 Capybara.default_max_wait_time = 5
 
 RSpec.configure do |config|
+  config.include SystemRevertHelper, type: :system
+
   config.before(:each, type: :system) do
     # 希望リストが一覧の右に開くのは lg（1024px）から。狭い画面で走らせると、
     # 希望リストに触るどの spec も、先にシートを開く操作を挟むことになる。

--- a/spec/system/book_card_spec.rb
+++ b/spec/system/book_card_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '本のカードの開閉' do
+  let!(:exchange) { create(:exchange, :registration) }
+  let!(:participation) { create(:participation, exchange:) }
+
+  # カードは 768px で止まるので、おすすめポイントの2行は100字あたりで埋まる。
+  # あらすじも折られる対象にあたるため、こちらは置かない
+  before do
+    create(:book, title: '長い本', summary: nil, participation: create(:participation, exchange:),
+                  recommendation: '読み終えたあと、しばらく本を閉じたまま座っていました。' * 6)
+    create(:book, title: '短い本', summary: nil, participation: create(:participation, exchange:),
+                  recommendation: '一息で読めます。')
+
+    log_in_as(participation.user)
+    visit exchange_path(exchange)
+  end
+
+  it '折られた本文のカードは、押すと開いて閉じられる' do
+    card = card('長い本')
+    card.find('[data-book-card-target="toggle"]').click
+
+    expect(card).to have_text('閉じる')
+
+    card.find('[data-book-card-target="toggle"]').click
+
+    expect(card).to have_text('続きを読む')
+  end
+
+  it '折れていない本文のカードには開くボタンが出ない' do
+    # ボタンが出るのは幅を測ってから。待たずに読むと、
+    # まだどのカードにも出ていないところを見て通ってしまう
+    expect(card('長い本')).to have_css('[data-book-card-target="toggle"]')
+
+    expect(card('短い本')).to have_no_css('[data-book-card-target="toggle"]')
+  end
+
+  def card(title)
+    find('#book_list li', text: title)
+  end
+end

--- a/spec/system/clipboard_spec.rb
+++ b/spec/system/clipboard_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '招待URLのコピー' do
+  let!(:exchange) { create(:exchange, :registration) }
+
+  before do
+    log_in_as(exchange.owner)
+    visit exchange_management_path(exchange)
+  end
+
+  it '押すと入力欄がまるごと選ばれる' do
+    copy_button.click
+
+    expect(selection).to eq(source_field.value)
+  end
+
+  it '押したことがボタンの文字に出て、しばらくすると戻る' do
+    revert_after(:clipboard, 300)
+
+    copy_button.click
+
+    expect(copy_button).to have_text('コピーしました')
+    expect(page).to have_css('[data-clipboard-target="button"]', exact_text: 'コピー')
+  end
+
+  # 選ばれた範囲は画面から読めない。焦点が外れていれば、
+  # 選ばれていても利用者の手ではコピーできない
+  def selection
+    source_field.evaluate_script(
+      'document.activeElement === this ? this.value.slice(this.selectionStart, this.selectionEnd) : ""'
+    )
+  end
+
+  def source_field
+    find('[data-clipboard-target="source"]')
+  end
+
+  def copy_button
+    find('[data-clipboard-target="button"]')
+  end
+end

--- a/spec/system/counter_spec.rb
+++ b/spec/system/counter_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'おすすめポイントの字数' do
+  let!(:participation) { create(:participation, exchange: create(:exchange, :registration)) }
+
+  before do
+    log_in_as(participation.user)
+    visit new_exchange_book_path(participation.exchange)
+  end
+
+  it '入力した文字数が出る' do
+    expect(page).to have_css('[data-counter-target="output"]', exact_text: '0')
+
+    fill_in 'book_recommendation', with: '波を数えるだけの話'
+
+    expect(page).to have_css('[data-counter-target="output"]', exact_text: '9')
+  end
+end

--- a/spec/system/reveal_spec.rb
+++ b/spec/system/reveal_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ギフトコードの伏せ字' do
+  let!(:participation) { create(:participation, exchange: create(:exchange, :registration)) }
+  let!(:book) { create(:book, participation:, gift_code: 'MYOWNGIFTCODE') }
+
+  before do
+    log_in_as(participation.user)
+    visit edit_exchange_book_path(book.exchange, book)
+  end
+
+  it '既定では伏せ字で、押すと開く' do
+    expect(page).to have_css('[data-reveal-target="field"][type="password"]')
+
+    reveal_button.click
+
+    expect(page).to have_css('[data-reveal-target="field"][type="text"]')
+    expect(page).to have_css('[data-reveal-target="warning"]')
+    expect(reveal_button).to have_text('隠す')
+  end
+
+  it 'もう一度押すと伏せ字に戻る' do
+    reveal_button.click
+    # 開かないまま2回押しても、伏せ字のままで通ってしまう
+    expect(page).to have_css('[data-reveal-target="field"][type="text"]')
+
+    reveal_button.click
+
+    expect(page).to have_css('[data-reveal-target="field"][type="password"]')
+    expect(page).to have_no_css('[data-reveal-target="warning"]')
+  end
+
+  it '開いたまま放置すると、自ら伏せ字へ戻る' do
+    revert_after(:reveal, 300)
+
+    reveal_button.click
+
+    expect(page).to have_css('[data-reveal-target="field"][type="text"]')
+    expect(page).to have_css('[data-reveal-target="field"][type="password"]')
+  end
+
+  def reveal_button
+    find('[data-reveal-target="button"]')
+  end
+end

--- a/spec/system/state_header_spec.rb
+++ b/spec/system/state_header_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '状態ヘッダーの畳んだ帯' do
+  let!(:exchange) { create(:exchange, :registration) }
+  let!(:participation) { create(:participation, exchange:) }
+
+  # 10冊置くのは、状態ヘッダーが画面の上へ抜けるところまで送れる高さを作るため
+  before do
+    create_list(:book, 10, participation: create(:participation, exchange:))
+
+    log_in_as(participation.user)
+    visit exchange_path(exchange)
+  end
+
+  it '状態ヘッダーが上へ出ると帯が出る' do
+    expect(page).to have_no_css(bar)
+
+    page.scroll_to(:bottom)
+
+    expect(page).to have_css(bar)
+  end
+
+  it '状態ヘッダーまで戻ると帯が消える' do
+    page.scroll_to(:bottom)
+    expect(page).to have_css(bar)
+
+    page.scroll_to(:top)
+
+    expect(page).to have_no_css(bar)
+  end
+
+  def bar
+    '[data-state-header-target="bar"]'
+  end
+end

--- a/spec/system/wish_sheet_spec.rb
+++ b/spec/system/wish_sheet_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '希望リストのシート' do
+  let!(:exchange) { create(:exchange, :wish) }
+  let!(:participation) { create(:participation, exchange:) }
+
+  before do
+    create(:wish, participation:, position: 1,
+                  book: create(:book, title: '赤の本', participation: create(:participation, exchange:)))
+
+    # 既定の 1400px では一覧の脇に開いたままで、畳むボタンそのものが出ない
+    page.current_window.resize_to(390, 780)
+
+    log_in_as(participation.user)
+    visit exchange_path(exchange)
+  end
+
+  it '狭い画面では畳まれていて、押すと中身が出る' do
+    expect(page).to have_no_css('#wish_list li')
+
+    sheet_toggle.click
+
+    expect(page).to have_css('#wish_list li', text: '赤の本')
+    expect(sheet_toggle['aria-expanded']).to eq('true')
+  end
+
+  it 'もう一度押すと畳まれる' do
+    sheet_toggle.click
+    expect(page).to have_css('#wish_list li', text: '赤の本')
+
+    sheet_toggle.click
+
+    expect(page).to have_no_css('#wish_list li')
+    expect(sheet_toggle['aria-expanded']).to eq('false')
+  end
+
+  def sheet_toggle
+    find('[data-wish-sheet-target="toggle"]')
+  end
+end


### PR DESCRIPTION
`wish_reorder` 以外の6つの Stimulus controller を system spec で押さえた。
足場（#194）はそのまま使い、`spec/support/system.rb` に helper を1つ足しただけ。

closes #195

## 完了条件

- [x] `reveal` — 既定で伏せ字、押すと開き、放置すると自ら伏せ字へ戻る
- [x] `book_card` — 開閉が効き、折れていない本文のカードには開くボタンが出ない
- [x] `wish_sheet` — 狭い画面で開閉が効く
- [x] `state_header` — 状態ヘッダーが上へ出たら帯に差し替わり、戻れば消える
- [x] `counter` — 入力した文字数が出る
- [x] `clipboard` — 押すと入力欄が選択され、ボタンの文字が変わる
- [x] 見た目そのもの（書体・配色・余白）は検証していない

## 例が空振りしていないことの確かめ方

controller の該当箇所をそれぞれ手元で外し、対応する例が落ちるところまで見た。

| 外したもの | 落ちた例 |
| --- | --- |
| `reveal` の `setTimeout` | 自ら伏せ字へ戻る |
| `reveal` の `toggle` の中身 | 3例すべて |
| `book_card` の `toggleAttribute` | 押すと開いて閉じられる |
| `book_card` の折れ具合の測定（常に出す） | 開くボタンが出ない |
| `wish_sheet` の `toggleAttribute` | 2例とも |
| `state_header` の出し分け（常に隠す／常に出す） | どちらでも2例とも |
| `counter` の `count` の中身 | 入力した文字数が出る |
| `clipboard` の `select` | 入力欄がまるごと選ばれる |
| `clipboard` の `#flash` と、その中の `setTimeout` | どちらでもボタンの文字 |

`reveal` の「もう一度押すと伏せ字に戻る」だけは、最初に書いた形では
`toggle` を外しても通ってしまった。伏せ字のままでも結果が同じになるため。
間に開いたことを見る行を足してある。

## 備考

- 戻るまでの長さは `data-*-revert-after-value` を縮めてから始める。既定の10秒と2秒を
  実時間で待つと、そのぶん実行時間が伸びる。長さを外から決められなくなれば例は落ちるので、
  仕掛けが消えたことには気付ける
- `clipboard` は `navigator.clipboard` が使える前提で通っている。Chrome は 127.0.0.1 を
  安全なコンテキストとして扱うため、入力欄の選択だけに落ちるほうの経路は
  この環境では通らない。CI も同じ条件になる見込みだが、確かめられるのはこの PR の CI が初めて
- `wish_sheet` だけ画面を 390px に狭める。畳むボタンは lg 未満にしか出ない。
  狭めた幅が例をまたいで持ち越されないことは、順を指定して走らせて確かめた
- ボタンの文字が戻るところ（`clipboard`）は issue の完了条件には無いが、
  `CLAUDE.md`「テスト > JavaScript の振る舞い」が挙げる「一定時間で戻るもの」に当たり、
  ほかに押さえている spec が無いので入れた

画面には触っていないので、ビジュアルガイドは参照していない。

`bin/rspec` は全体で 1065 examples / 0 failures、`bin/rubocop` と `bin/ci` も通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)