### PR TITLE
デプロイの道具を devcontainer に入れる

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -38,6 +38,29 @@ Claude Code をホストから隔離して動かすための開発環境。
   Claude Code からも読める
 - GitHub へのアクセスが必要なら、リポジトリに限定した短命のトークンを使う
 
+## デプロイの道具
+
+`docker` / `aws` / `terraform` が入っている。**認証情報はこのコンテナに置かない。**
+上の「守るべきこと」がそのまま当たる。置けば Claude Code からも読める。
+
+| | 中で通るもの | ホストで打つもの |
+|---|---|---|
+| Terraform | `fmt`、`validate`（`init -backend=false` の後） | `init`、`plan`、`apply` |
+| Kamal | イメージのビルド | `deploy`、`rollback` |
+| AWS CLI | 無し | すべて |
+
+`terraform init` が認証を要るのは、state を S3 バックエンドに置いているため。
+`kamal deploy` にはレジストリへの push と本番の `RAILS_MASTER_KEY` が要る。
+どちらもここでは通らない。**書くのはコンテナの中、配るのはホストから**になる。
+
+Docker を入れてあるのは、`Dockerfile` が通るかを手元で確かめるため。
+ビルドだけなら認証は要らない。
+
+ホストの Docker ソケットは渡していない。渡すと、コンテナから
+`docker run -v /:/host` でホストの全ファイルに手が届いてしまい、
+「何から守られているか」が成り立たなくなる。代わりに docker-in-docker を使い、
+コンテナの中に閉じた dockerd を持つ。`compose.yaml` の `privileged` はこのため。
+
 ## 権限プロンプトについて
 
 通信制限がないため、`--dangerously-skip-permissions` は常用しないこと。
@@ -52,6 +75,7 @@ Claude Code をホストから隔離して動かすための開発環境。
 | Claude Code の認証・設定・履歴 | 名前付きボリューム（プロジェクトごとに分離） |
 | インストールした gem | 名前付きボリューム `okuribon_bundle` |
 | Postgres のデータ | 名前付きボリューム `okuribon_postgres` |
+| Docker のイメージ | 名前付きボリューム `okuribon_docker` |
 | ソースコード | ホスト側のリポジトリ（bind mount） |
 
 コンテナを作り直しても再ログインは不要。完全に消したい場合は該当のボリュームを削除する。

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -49,7 +49,7 @@ Claude Code をホストから隔離して動かすための開発環境。
 | Kamal | イメージのビルド | `deploy`、`rollback` |
 | AWS CLI | 無し | すべて |
 
-`terraform init` が認証を要るのは、state を S3 バックエンドに置いているため。
+`terraform init` に認証が要るのは、state を S3 バックエンドに置いているため。
 `kamal deploy` にはレジストリへの push と本番の `RAILS_MASTER_KEY` が要る。
 どちらもここでは通らない。**書くのはコンテナの中、配るのはホストから**になる。
 

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -8,6 +8,10 @@ services:
     volumes:
       - ..:/workspaces/okuribon:cached
       - bundle:/bundle
+      # イメージをボリュームに置く。コンテナを作り直すたびに pull し直さずに済む
+      - docker:/var/lib/docker
+    # docker-in-docker が中で dockerd を起こすために要る
+    privileged: true
     # devcontainer 側がプロセスを管理するので、居座るだけでよい
     command: sleep infinity
     environment:
@@ -41,3 +45,4 @@ services:
 volumes:
   postgres:
   bundle:
+  docker:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },
 


### PR DESCRIPTION
Terraform でインフラを組むにあたって、`terraform` / `aws` / `docker` を devcontainer に入れた。
issue に紐づかない環境整備なので `closes` は書いていない。

## docker-in-docker を採った

ホストの Docker ソケットを渡す docker-outside-of-docker だと、コンテナから
`docker run -v /:/host` でホストの全ファイルに手が届く。`.devcontainer/README.md` の
「何から守られているか」が謳っている隔離が、そこだけ崩れることになる。
docker-in-docker なら Docker がコンテナの中で閉じる。`privileged: true` はその代償。

イメージは名前付きボリューム `okuribon_docker` に置いた。コンテナを作り直すたびに
pull し直さずに済む。

## 認証情報は置かない

`.devcontainer/README.md`「守るべきこと」の方針をそのまま保った。コンテナ内で
読めるものは Claude Code からも読めるため、AWS の認証情報も本番の
`RAILS_MASTER_KEY` も置かない。**書くのはコンテナの中、配るのはホストから**になる。

| | 中で通る | ホストで打つ |
|---|---|---|
| Terraform | `fmt`、`validate`（`init -backend=false` の後） | `init`、`plan`、`apply` |
| Kamal | イメージのビルド | `deploy`、`rollback` |
| AWS CLI | 無し | すべて |

`terraform init` に認証が要るのは、state を S3 バックエンドに置くため。
`aws` は認証情報なしではほとんど使い道が無いが、道具として揃えておく。

## マージ後にお願いすること

**devcontainer の再ビルドが要る。** そのとき `devcontainer-lock.json` が解決されるので、
更新された差分は別途コミットしてほしい。ここでは解決できないため入れていない。

## 確認したこと

- `.devcontainer/compose.yaml` と `devcontainer.json` の構文（YAML / JSONC のパース）
- `bin/rspec` 1088 examples, 0 failures
- `bin/rubocop` 153 files, no offenses
- `bin/ci` 通過

**再ビルドはまだしていない。** features が実際に解決されるかは、手元での再ビルドが
最初の確認になる。

画面には触れていないため、ビジュアルガイドの参照は要らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
